### PR TITLE
Change naming scheme

### DIFF
--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -178,8 +178,8 @@ void Partitioner::save_metadata(const std::string& filename) const
   int top_ids_vid, bottom_ids_vid, left_ids_vid, right_ids_vid;
   int top_halos_vid, bottom_halos_vid, left_halos_vid, right_halos_vid;
   // Bounding boxes group
-  NC_CHECK(nc_def_var(bbox_gid, "global_x", NC_INT, 1, &dimid, &top_x_vid));
-  NC_CHECK(nc_def_var(bbox_gid, "global_y", NC_INT, 1, &dimid, &top_y_vid));
+  NC_CHECK(nc_def_var(bbox_gid, "domain_x", NC_INT, 1, &dimid, &top_x_vid));
+  NC_CHECK(nc_def_var(bbox_gid, "domain_y", NC_INT, 1, &dimid, &top_y_vid));
   NC_CHECK(
       nc_def_var(bbox_gid, "local_extent_x", NC_INT, 1, &dimid, &cnt_x_vid));
   NC_CHECK(

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -181,9 +181,9 @@ void Partitioner::save_metadata(const std::string& filename) const
   NC_CHECK(nc_def_var(bbox_gid, "domain_x", NC_INT, 1, &dimid, &top_x_vid));
   NC_CHECK(nc_def_var(bbox_gid, "domain_y", NC_INT, 1, &dimid, &top_y_vid));
   NC_CHECK(
-      nc_def_var(bbox_gid, "local_extent_x", NC_INT, 1, &dimid, &cnt_x_vid));
+      nc_def_var(bbox_gid, "domain_extent_x", NC_INT, 1, &dimid, &cnt_x_vid));
   NC_CHECK(
-      nc_def_var(bbox_gid, "local_extent_y", NC_INT, 1, &dimid, &cnt_y_vid));
+      nc_def_var(bbox_gid, "domain_extent_y", NC_INT, 1, &dimid, &cnt_y_vid));
   // Connectivity group
   NC_CHECK(nc_def_var(connectivity_gid, "top_neighbors", NC_INT, 1, &dimid,
                       &top_num_vid));

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file Partitioner.cpp
  * @author Athena Elafrou <ae488@cam.ac.uk>
- * @date 25 June 2022
+ * @date 20 August 2024
  */
 
 #include "Partitioner.hpp"
@@ -154,8 +154,8 @@ void Partitioner::save_metadata(const std::string& filename) const
   // the C interface
   const int NDIMS = 2;
   int dimid_global[NDIMS];
-  NC_CHECK(nc_def_dim(nc_id, "globalX", _global_ext_0, &dimid_global[0]));
-  NC_CHECK(nc_def_dim(nc_id, "globalY", _global_ext_1, &dimid_global[1]));
+  NC_CHECK(nc_def_dim(nc_id, "NX", _global_ext_0, &dimid_global[0]));
+  NC_CHECK(nc_def_dim(nc_id, "NY", _global_ext_1, &dimid_global[1]));
 
 
   // Define dimensions in netCDF file

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -104,9 +104,9 @@ public:
    * Saves the boxes and connectivity information of the latest 2D domain
    * decomposition in a NetCDF file. The NetCDF file contains a dimension P
    * equal to the number of partitions and integer variables domain_x(P),
-   * domain_y(P), local_extent_x(P) and local_extent_y(P). Variables domain_x
+   * domain_y(P), domain_extent_x(P) and domain_extent_y(P). Variables domain_x
    * and domain_y are defined as the coordinates of the upper left corner of the
-   * box for each partition, while the local_extent_x and local_extent_y
+   * box for each partition, while the domain_extent_x and domain_extent_y
    * variables define the local extent of the x and y dimensions respectively.
    * The file also defines the variables X_neighbors(P), X_neighbor_ids(X_dim)
    * and X_neighbor_halos(X_dim), where X is top/bottom/left/right, which

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -103,9 +103,9 @@ public:
    *
    * Saves the boxes and connectivity information of the latest 2D domain
    * decomposition in a NetCDF file. The NetCDF file contains a dimension P
-   * equal to the number of partitions and integer variables global_x(P),
-   * global_y(P), local_extent_x(P) and local_extent_y(P). Variables global_x
-   * and global_y are defined as the coordinates of the upper left corner of the
+   * equal to the number of partitions and integer variables domain_x(P),
+   * domain_y(P), local_extent_x(P) and local_extent_y(P). Variables domain_x
+   * and domain_y are defined as the coordinates of the upper left corner of the
    * box for each partition, while the local_extent_x and local_extent_y
    * variables define the local extent of the x and y dimensions respectively.
    * The file also defines the variables X_neighbors(P), X_neighbor_ids(X_dim)

--- a/README.md
+++ b/README.md
@@ -130,15 +130,15 @@ dimensions:
 
 group: bounding_boxes {
   variables:
-	int global_x(P) ;
-	int global_y(P) ;
-	int local_extent_x(P) ;
-	int local_extent_y(P) ;
+	int domain_x(P) ;
+	int domain_y(P) ;
+	int domain_extent_x(P) ;
+	int domain_extent_y(P) ;
   data:
-	global_x = 0, 16 ;
-	global_y = 0, 0 ;
-	local_extent_x = 16, 14 ;
-	local_extent_y = 30, 30 ;
+	domain_x = 0, 16 ;
+	domain_y = 0, 0 ;
+	domain_extent_x = 16, 14 ;
+	domain_extent_y = 30, 30 ;
   } // group bounding_boxes
 
 group: connectivity {
@@ -169,7 +169,7 @@ group: connectivity {
 
 ```
 
-The netCDF variables `global_x/y` are defined as the coordinates of the upper left corner of the bounding box for each MPI process using zero-based indexing and `local_extent_x/y` are the extents in the corresponding dimensions of the bounding box for each MPI process. The file also defines the variables `X_neighbors(P)`, `X_neighbor_ids(X_dim)` and `X_neighbor_halos(X_dim)`, where `X` is `top/bottom/left/right`, which correspond to the number of neighbors per process, the neighbor IDs and halo sizes of each process sorted from lower to higher MPI rank.
+The netCDF variables `domain_x/y` are defined as the coordinates of the upper left corner of the bounding box for each MPI process using zero-based indexing and `domain_extent_x/y` are the extents in the corresponding dimensions of the bounding box for each MPI process. The file also defines the variables `X_neighbors(P)`, `X_neighbor_ids(X_dim)` and `X_neighbor_halos(X_dim)`, where `X` is `top/bottom/left/right`, which correspond to the number of neighbors per process, the neighbor IDs and halo sizes of each process sorted from lower to higher MPI rank.
 
 ## Layout
 
@@ -181,18 +181,18 @@ To remove disambiguity we renamed the outputs produced in the `partition_metadat
 ```
 netcdf partition_metadata_3 {
 dimensions:
- globalX = 30 ; (NX)
- globalY = 24 ; (NY)
+ NX = 30 ;
+ NY = 24 ;
  P = 3 ;
  T = 2 ;                                              0            12        24
  B = 2 ;                                               ┌──────────────────────►  y
  L = 1 ;                                               │
  R = 1 ;                                               │  ┌─────────┬─────────┐
 group: bounding_boxes {                                │  │         │         │
-   global_x = 0, 0, 20 ;  (domain_x)                   │  │         │         │
-   global_y = 0, 12, 0 ;  (domain_y)                   │  │         │         │
-   local_extent_x = 20, 20, 10 ; (domain_extent_x)     │  │    0    │    1    │
-   local_extent_y = 12, 12, 24 ; (domain_extent_y)     │  │         │         │
+   domain_x = 0, 0, 20 ;                               │  │         │         │
+   domain_y = 0, 12, 0 ;                               │  │         │         │
+   domain_extent_x = 20, 20, 10 ;                      │  │    0    │    1    │
+   domain_extent_y = 12, 12, 24 ;                      │  │         │         │
   } // group bounding_boxes                            │  │         │         │
 group: connectivity {                                  │  │         │         │
    top_neighbors = 0, 0, 2 ;                        20 │  ├─────────┴─────────┤


### PR DESCRIPTION
Linked PR: https://github.com/nextsimhub/nextsimdg/pull/652.

At meeting in Bergen, it was decided that we should rename some of the variables printed in the NetCDF metadata as follows:
```
globalX -> NX
globalY -> NY
global_x ->  domain_x
global_y ->  domain_y
local_extent_x -> domain_extent_x
local_extent_y -> domain_extent_y
```