### PR TITLE
feat: remove block option from command line args

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -32,10 +32,6 @@ int main(int argc, char* argv[])
      "First spatial dimension in netCDF grid file")
     ("dim1", po::value<string>()->default_value("y"),
      "Second spatial dimension in netCDF grid file")
-    ("blk0", po::value<int>()->default_value(1),
-     "Blocking factor in first dimension")
-    ("blk1", po::value<int>()->default_value(1),
-     "Blocking factor in second dimension")
     ("mask,m", po::value<string>()->default_value("mask"),
      "Mask variable name in netCDF grid file")
     ("ignore-mask", po::bool_switch()->default_value(false),
@@ -55,12 +51,18 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  // remove block options from command line. Currently, nextsimdg does not use
+  // the concept of blocks. (See issue
+  // https://github.com/nextsimhub/domain_decomp/issues/39)
+  int blk0 = 1;
+  int blk1 = 1;
+
   // Build grid from netCDF file
   Grid* grid
       = Grid::create(comm, vm["grid"].as<string>(), vm["dim0"].as<string>(),
                      vm["dim1"].as<string>(), vm["mask"].as<string>(),
-                     vm["blk0"].as<int>(), vm["blk1"].as<int>(),
-		     vm["ignore-mask"].as<bool>());
+                     blk0, blk1,
+                     vm["ignore-mask"].as<bool>());
 
   // Create a Zoltan partitioner
   Partitioner* partitioner = Partitioner::Factory::create(


### PR DESCRIPTION
fixes #39 

Currently user can override the default block arguments (`--blk0` and `--blk1`). Setting them to anything other than the default (1) would lead to undefined behaviour in `nextsimdg`.

This PR removes the option.