### PR TITLE
Partitioner refactor 1

### DIFF
--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -109,12 +109,13 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_def_dim(nc_id, "NY", _global_ext_1, &dimid_global[1]));
 
     // Define dimensions in netCDF file
-    int dimid, top_dimid, bottom_dimid, left_dimid, right_dimid;
+    int dimid;
+    std::vector<int> dimids(4);
     NC_CHECK(nc_def_dim(nc_id, "P", _num_procs, &dimid));
-    NC_CHECK(nc_def_dim(nc_id, "T", dims[3], &top_dimid));
-    NC_CHECK(nc_def_dim(nc_id, "B", dims[2], &bottom_dimid));
-    NC_CHECK(nc_def_dim(nc_id, "L", dims[0], &left_dimid));
-    NC_CHECK(nc_def_dim(nc_id, "R", dims[1], &right_dimid));
+    NC_CHECK(nc_def_dim(nc_id, "T", dims[3], &dimids[3]));
+    NC_CHECK(nc_def_dim(nc_id, "B", dims[2], &dimids[2]));
+    NC_CHECK(nc_def_dim(nc_id, "L", dims[0], &dimids[0]));
+    NC_CHECK(nc_def_dim(nc_id, "R", dims[1], &dimids[1]));
 
     // Define groups in netCDF file
     int bbox_gid, connectivity_gid;
@@ -135,24 +136,24 @@ void Partitioner::save_metadata(const std::string& filename) const
     // Connectivity group
     NC_CHECK(nc_def_var(connectivity_gid, "top_neighbours", NC_INT, 1, &dimid, &top_num_vid));
     NC_CHECK(
-        nc_def_var(connectivity_gid, "top_neighbour_ids", NC_INT, 1, &top_dimid, &top_ids_vid));
+        nc_def_var(connectivity_gid, "top_neighbour_ids", NC_INT, 1, &dimids[3], &top_ids_vid));
     NC_CHECK(
-        nc_def_var(connectivity_gid, "top_neighbour_halos", NC_INT, 1, &top_dimid, &top_halos_vid));
+        nc_def_var(connectivity_gid, "top_neighbour_halos", NC_INT, 1, &dimids[3], &top_halos_vid));
     NC_CHECK(nc_def_var(connectivity_gid, "bottom_neighbours", NC_INT, 1, &dimid, &bottom_num_vid));
     NC_CHECK(nc_def_var(
-        connectivity_gid, "bottom_neighbour_ids", NC_INT, 1, &bottom_dimid, &bottom_ids_vid));
+        connectivity_gid, "bottom_neighbour_ids", NC_INT, 1, &dimids[2], &bottom_ids_vid));
     NC_CHECK(nc_def_var(
-        connectivity_gid, "bottom_neighbour_halos", NC_INT, 1, &bottom_dimid, &bottom_halos_vid));
+        connectivity_gid, "bottom_neighbour_halos", NC_INT, 1, &dimids[2], &bottom_halos_vid));
     NC_CHECK(nc_def_var(connectivity_gid, "left_neighbours", NC_INT, 1, &dimid, &left_num_vid));
     NC_CHECK(
-        nc_def_var(connectivity_gid, "left_neighbour_ids", NC_INT, 1, &left_dimid, &left_ids_vid));
+        nc_def_var(connectivity_gid, "left_neighbour_ids", NC_INT, 1, &dimids[0], &left_ids_vid));
     NC_CHECK(nc_def_var(
-        connectivity_gid, "left_neighbour_halos", NC_INT, 1, &left_dimid, &left_halos_vid));
+        connectivity_gid, "left_neighbour_halos", NC_INT, 1, &dimids[0], &left_halos_vid));
     NC_CHECK(nc_def_var(connectivity_gid, "right_neighbours", NC_INT, 1, &dimid, &right_num_vid));
+    NC_CHECK(
+        nc_def_var(connectivity_gid, "right_neighbour_ids", NC_INT, 1, &dimids[1], &right_ids_vid));
     NC_CHECK(nc_def_var(
-        connectivity_gid, "right_neighbour_ids", NC_INT, 1, &right_dimid, &right_ids_vid));
-    NC_CHECK(nc_def_var(
-        connectivity_gid, "right_neighbour_halos", NC_INT, 1, &right_dimid, &right_halos_vid));
+        connectivity_gid, "right_neighbour_halos", NC_INT, 1, &dimids[1], &right_halos_vid));
 
     // Write metadata to file
     NC_CHECK(nc_enddef(nc_id));

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -55,9 +55,9 @@ void Partitioner::save_mask(const std::string& filename) const
     // the C interface
     const int NDIMS = 2; // TODO: Why redeclared?
     int dimid[NDIMS];
-    std::vector<std::string> dim_names = { "x", "y" };
+    std::vector<std::string> dim_chars = { "x", "y" };
     for (int idx = 0; idx < NDIMS; idx++) {
-        NC_CHECK(nc_def_dim(nc_id, dim_names[idx].c_str(), _global_ext[idx], &dimid[idx]));
+        NC_CHECK(nc_def_dim(nc_id, dim_chars[idx].c_str(), _global_ext[idx], &dimid[idx]));
     }
 
     // Create variables
@@ -93,10 +93,9 @@ void Partitioner::save_metadata(const std::string& filename) const
     // the C interface
     const int NDIMS = 2; // TODO: Why redeclared?
     int dimid_global[NDIMS];
-    std::vector<std::string> global_dim_names = { "NX", "NY" };
     for (int idx = 0; idx < NDIMS; idx++) {
-        NC_CHECK(
-            nc_def_dim(nc_id, global_dim_names[idx].c_str(), _global_ext[idx], &dimid_global[idx]));
+        NC_CHECK(nc_def_dim(
+            nc_id, global_extent_names[idx].c_str(), _global_ext[idx], &dimid_global[idx]));
     }
 
     // There are two neighbours for each dimension
@@ -122,9 +121,8 @@ void Partitioner::save_metadata(const std::string& filename) const
     int dimid;
     std::vector<int> dimids(NNBRS);
     NC_CHECK(nc_def_dim(nc_id, "P", _total_num_procs, &dimid));
-    std::vector<std::string> dim_letters = { "L", "R", "B", "T" };
     for (int idx = 0; idx < NNBRS; idx++) {
-        NC_CHECK(nc_def_dim(nc_id, dim_letters[idx].c_str(), dims[idx], &dimids[idx]));
+        NC_CHECK(nc_def_dim(nc_id, dir_chars[idx].c_str(), dims[idx], &dimids[idx]));
     }
 
     // Define groups in netCDF file
@@ -138,13 +136,11 @@ void Partitioner::save_metadata(const std::string& filename) const
     int num_vid[NNBRS];
     int ids_vid[NNBRS];
     int halos_vid[NNBRS];
-    std::vector<std::string> dir_names = { "left", "right", "bottom", "top" };
-    std::vector<std::string> dim_names = { "x", "y" };
     for (int idx = 0; idx < NNBRS; idx++) {
         // Bounding boxes group
         NC_CHECK(nc_def_var(
-            bbox_gid, ("domain_" + dim_names[idx]).c_str(), NC_INT, 1, &dimid, &top_vid[idx]));
-        NC_CHECK(nc_def_var(bbox_gid, ("domain_extent_" + dim_names[idx]).c_str(), NC_INT, 1,
+            bbox_gid, ("domain_" + dim_chars[idx]).c_str(), NC_INT, 1, &dimid, &top_vid[idx]));
+        NC_CHECK(nc_def_var(bbox_gid, ("domain_extent_" + dim_chars[idx]).c_str(), NC_INT, 1,
             &dimid, &cnt_vid[idx]));
         // Connectivity group
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[idx] + "_neighbours").c_str(), NC_INT, 1,

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -112,10 +112,10 @@ void Partitioner::save_metadata(const std::string& filename) const
     int dimid;
     std::vector<int> dimids(4);
     NC_CHECK(nc_def_dim(nc_id, "P", _num_procs, &dimid));
-    NC_CHECK(nc_def_dim(nc_id, "T", dims[3], &dimids[3]));
-    NC_CHECK(nc_def_dim(nc_id, "B", dims[2], &dimids[2]));
-    NC_CHECK(nc_def_dim(nc_id, "L", dims[0], &dimids[0]));
-    NC_CHECK(nc_def_dim(nc_id, "R", dims[1], &dimids[1]));
+    std::vector<std::string> dim_letters = { "L", "R", "B", "T" };
+    for (int idx = 0; idx < 4; idx++) {
+        NC_CHECK(nc_def_dim(nc_id, dim_letters[idx].c_str(), dims[idx], &dimids[idx]));
+    }
 
     // Define groups in netCDF file
     int bbox_gid, connectivity_gid;
@@ -128,31 +128,21 @@ void Partitioner::save_metadata(const std::string& filename) const
     std::vector<int> num_vid(4);
     std::vector<int> ids_vid(4);
     std::vector<int> halos_vid(4);
+    std::vector<std::string> dim_names = { "left", "right", "bottom", "top" };
     // Bounding boxes group
     NC_CHECK(nc_def_var(bbox_gid, "domain_x", NC_INT, 1, &dimid, &top_x_vid));
     NC_CHECK(nc_def_var(bbox_gid, "domain_y", NC_INT, 1, &dimid, &top_y_vid));
     NC_CHECK(nc_def_var(bbox_gid, "domain_extent_x", NC_INT, 1, &dimid, &cnt_x_vid));
     NC_CHECK(nc_def_var(bbox_gid, "domain_extent_y", NC_INT, 1, &dimid, &cnt_y_vid));
     // Connectivity group
-    NC_CHECK(nc_def_var(connectivity_gid, "top_neighbours", NC_INT, 1, &dimid, &num_vid[3]));
-    NC_CHECK(nc_def_var(connectivity_gid, "top_neighbour_ids", NC_INT, 1, &dimids[3], &ids_vid[3]));
-    NC_CHECK(
-        nc_def_var(connectivity_gid, "top_neighbour_halos", NC_INT, 1, &dimids[3], &halos_vid[3]));
-    NC_CHECK(nc_def_var(connectivity_gid, "bottom_neighbours", NC_INT, 1, &dimid, &num_vid[2]));
-    NC_CHECK(
-        nc_def_var(connectivity_gid, "bottom_neighbour_ids", NC_INT, 1, &dimids[2], &ids_vid[2]));
-    NC_CHECK(nc_def_var(
-        connectivity_gid, "bottom_neighbour_halos", NC_INT, 1, &dimids[2], &halos_vid[2]));
-    NC_CHECK(nc_def_var(connectivity_gid, "left_neighbours", NC_INT, 1, &dimid, &num_vid[0]));
-    NC_CHECK(
-        nc_def_var(connectivity_gid, "left_neighbour_ids", NC_INT, 1, &dimids[0], &ids_vid[0]));
-    NC_CHECK(
-        nc_def_var(connectivity_gid, "left_neighbour_halos", NC_INT, 1, &dimids[0], &halos_vid[0]));
-    NC_CHECK(nc_def_var(connectivity_gid, "right_neighbours", NC_INT, 1, &dimid, &num_vid[1]));
-    NC_CHECK(
-        nc_def_var(connectivity_gid, "right_neighbour_ids", NC_INT, 1, &dimids[1], &ids_vid[1]));
-    NC_CHECK(nc_def_var(
-        connectivity_gid, "right_neighbour_halos", NC_INT, 1, &dimids[1], &halos_vid[1]));
+    for (int idx = 0; idx < 4; idx++) {
+        NC_CHECK(nc_def_var(connectivity_gid, (dim_names[idx] + "_neighbours").c_str(), NC_INT, 1,
+            &dimid, &num_vid[idx]));
+        NC_CHECK(nc_def_var(connectivity_gid, (dim_names[idx] + "_neighbour_ids").c_str(), NC_INT,
+            1, &dimids[idx], &ids_vid[idx]));
+        NC_CHECK(nc_def_var(connectivity_gid, (dim_names[idx] + "_neighbour_halos").c_str(), NC_INT,
+            1, &dimids[idx], &halos_vid[idx]));
+    }
 
     // Write metadata to file
     NC_CHECK(nc_enddef(nc_id));

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -126,8 +126,8 @@ void Partitioner::save_metadata(const std::string& filename) const
     int top_x_vid, top_y_vid;
     int cnt_x_vid, cnt_y_vid;
     std::vector<int> num_vid(4);
-    int top_ids_vid, bottom_ids_vid, left_ids_vid, right_ids_vid;
-    int top_halos_vid, bottom_halos_vid, left_halos_vid, right_halos_vid;
+    std::vector<int> ids_vid(4);
+    std::vector<int> halos_vid(4);
     // Bounding boxes group
     NC_CHECK(nc_def_var(bbox_gid, "domain_x", NC_INT, 1, &dimid, &top_x_vid));
     NC_CHECK(nc_def_var(bbox_gid, "domain_y", NC_INT, 1, &dimid, &top_y_vid));
@@ -135,25 +135,24 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_def_var(bbox_gid, "domain_extent_y", NC_INT, 1, &dimid, &cnt_y_vid));
     // Connectivity group
     NC_CHECK(nc_def_var(connectivity_gid, "top_neighbours", NC_INT, 1, &dimid, &num_vid[3]));
+    NC_CHECK(nc_def_var(connectivity_gid, "top_neighbour_ids", NC_INT, 1, &dimids[3], &ids_vid[3]));
     NC_CHECK(
-        nc_def_var(connectivity_gid, "top_neighbour_ids", NC_INT, 1, &dimids[3], &top_ids_vid));
-    NC_CHECK(
-        nc_def_var(connectivity_gid, "top_neighbour_halos", NC_INT, 1, &dimids[3], &top_halos_vid));
+        nc_def_var(connectivity_gid, "top_neighbour_halos", NC_INT, 1, &dimids[3], &halos_vid[3]));
     NC_CHECK(nc_def_var(connectivity_gid, "bottom_neighbours", NC_INT, 1, &dimid, &num_vid[2]));
+    NC_CHECK(
+        nc_def_var(connectivity_gid, "bottom_neighbour_ids", NC_INT, 1, &dimids[2], &ids_vid[2]));
     NC_CHECK(nc_def_var(
-        connectivity_gid, "bottom_neighbour_ids", NC_INT, 1, &dimids[2], &bottom_ids_vid));
-    NC_CHECK(nc_def_var(
-        connectivity_gid, "bottom_neighbour_halos", NC_INT, 1, &dimids[2], &bottom_halos_vid));
+        connectivity_gid, "bottom_neighbour_halos", NC_INT, 1, &dimids[2], &halos_vid[2]));
     NC_CHECK(nc_def_var(connectivity_gid, "left_neighbours", NC_INT, 1, &dimid, &num_vid[0]));
     NC_CHECK(
-        nc_def_var(connectivity_gid, "left_neighbour_ids", NC_INT, 1, &dimids[0], &left_ids_vid));
-    NC_CHECK(nc_def_var(
-        connectivity_gid, "left_neighbour_halos", NC_INT, 1, &dimids[0], &left_halos_vid));
+        nc_def_var(connectivity_gid, "left_neighbour_ids", NC_INT, 1, &dimids[0], &ids_vid[0]));
+    NC_CHECK(
+        nc_def_var(connectivity_gid, "left_neighbour_halos", NC_INT, 1, &dimids[0], &halos_vid[0]));
     NC_CHECK(nc_def_var(connectivity_gid, "right_neighbours", NC_INT, 1, &dimid, &num_vid[1]));
     NC_CHECK(
-        nc_def_var(connectivity_gid, "right_neighbour_ids", NC_INT, 1, &dimids[1], &right_ids_vid));
+        nc_def_var(connectivity_gid, "right_neighbour_ids", NC_INT, 1, &dimids[1], &ids_vid[1]));
     NC_CHECK(nc_def_var(
-        connectivity_gid, "right_neighbour_halos", NC_INT, 1, &dimids[1], &right_halos_vid));
+        connectivity_gid, "right_neighbour_halos", NC_INT, 1, &dimids[1], &halos_vid[1]));
 
     // Write metadata to file
     NC_CHECK(nc_enddef(nc_id));
@@ -171,37 +170,17 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_put_var1_int(bbox_gid, cnt_x_vid, &start, &_local_ext_0_new));
     NC_CHECK(nc_var_par_access(bbox_gid, cnt_y_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_var1_int(bbox_gid, cnt_y_vid, &start, &_local_ext_1_new));
-
     for (int idx = 0; idx < 4; idx++) {
         NC_CHECK(nc_var_par_access(connectivity_gid, num_vid[idx], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(connectivity_gid, num_vid[idx], &start, &num_neighbours[idx]));
+        start = offsets[idx];
+        count = num_neighbours[idx];
+        NC_CHECK(nc_var_par_access(connectivity_gid, ids_vid[idx], NC_COLLECTIVE));
+        NC_CHECK(nc_put_vara_int(connectivity_gid, ids_vid[idx], &start, &count, ids[idx].data()));
+        NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid[idx], NC_COLLECTIVE));
+        NC_CHECK(
+            nc_put_vara_int(connectivity_gid, halos_vid[idx], &start, &count, halos[idx].data()));
     }
-
-    start = offsets[0];
-    count = num_neighbours[0];
-    NC_CHECK(nc_var_par_access(connectivity_gid, left_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, left_ids_vid, &start, &count, ids[0].data()));
-    NC_CHECK(nc_var_par_access(connectivity_gid, left_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, left_halos_vid, &start, &count, halos[0].data()));
-    start = offsets[1];
-    count = num_neighbours[1];
-    NC_CHECK(nc_var_par_access(connectivity_gid, right_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, right_ids_vid, &start, &count, ids[1].data()));
-    NC_CHECK(nc_var_par_access(connectivity_gid, right_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, right_halos_vid, &start, &count, halos[1].data()));
-    start = offsets[2];
-    count = num_neighbours[2];
-    NC_CHECK(nc_var_par_access(connectivity_gid, bottom_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, bottom_ids_vid, &start, &count, ids[2].data()));
-    NC_CHECK(nc_var_par_access(connectivity_gid, bottom_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, bottom_halos_vid, &start, &count, halos[2].data()));
-    start = offsets[3];
-    count = num_neighbours[3];
-    NC_CHECK(nc_var_par_access(connectivity_gid, top_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, top_ids_vid, &start, &count, ids[3].data()));
-    NC_CHECK(nc_var_par_access(connectivity_gid, top_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, top_halos_vid, &start, &count, halos[3].data()));
-
     NC_CHECK(nc_close(nc_id));
 }
 

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -30,24 +30,9 @@ void Partitioner::get_bounding_box(
     local_ext_1 = _local_ext_1_new;
 }
 
-void Partitioner::get_neighbours(
-    std::vector<int>& ids, std::vector<int>& halo_sizes, int dim, bool start) const
+void Partitioner::get_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes, int idx) const
 {
-    std::map<int, int> neighbours;
-    if (dim == 0) {
-        if (start) {
-            neighbours = _bottom_neighbours;
-        } else {
-            neighbours = _top_neighbours;
-        }
-    } else if (dim == 1) {
-        if (start) {
-            neighbours = _left_neighbours;
-        } else {
-            neighbours = _right_neighbours;
-        }
-    }
-    for (auto it = neighbours.begin(); it != neighbours.end(); ++it) {
+    for (auto it = _neighbours[idx].begin(); it != _neighbours[idx].end(); ++it) {
         ids.push_back(it->first);
         halo_sizes.push_back(it->second);
     }
@@ -100,10 +85,10 @@ void Partitioner::save_metadata(const std::string& filename) const
     // Prepare neighbour data
     std::vector<int> top_ids, bottom_ids, left_ids, right_ids;
     std::vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    get_neighbours(left_ids, left_halos, 0, true);
-    get_neighbours(right_ids, right_halos, 0, false);
-    get_neighbours(bottom_ids, bottom_halos, 1, true);
-    get_neighbours(top_ids, top_halos, 1, false);
+    get_neighbours(left_ids, left_halos, 0);
+    get_neighbours(right_ids, right_halos, 1);
+    get_neighbours(bottom_ids, bottom_halos, 2);
+    get_neighbours(top_ids, top_halos, 3);
     int top_num_neighbours = top_ids.size();
     int bottom_num_neighbours = bottom_ids.size();
     int left_num_neighbours = left_ids.size();
@@ -280,13 +265,13 @@ void Partitioner::discover_neighbours()
                 && bottom_right_1[i] <= top_right_1[_rank]
                 && (top_left_0[_rank] - bottom_left_0[i] == 1)) {
                 int halo_size = bottom_right_1[i] - top_left_1[_rank] + 1;
-                _top_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[3].insert(std::pair<int, int>(i, halo_size));
             }
             if (top_right_1[_rank] >= bottom_left_1[i] && top_right_1[_rank] <= bottom_right_1[i]
                 && bottom_left_1[i] >= top_left_1[_rank]
                 && (top_right_0[_rank] - bottom_right_0[i] == 1)) {
                 int halo_size = top_right_1[_rank] - bottom_left_1[i] + 1;
-                _top_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[3].insert(std::pair<int, int>(i, halo_size));
             }
         }
     }
@@ -298,13 +283,13 @@ void Partitioner::discover_neighbours()
                 && top_right_1[i] <= bottom_right_1[_rank]
                 && (top_left_0[i] - bottom_left_0[_rank] == 1)) {
                 int halo_size = top_right_1[i] - bottom_left_1[_rank] + 1;
-                _bottom_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[2].insert(std::pair<int, int>(i, halo_size));
             }
             if (bottom_right_1[_rank] >= top_left_1[i] && bottom_right_1[_rank] <= top_right_1[i]
                 && top_left_1[i] >= bottom_left_1[_rank]
                 && (top_right_0[i] - bottom_right_0[_rank] == 1)) {
                 int halo_size = bottom_right_1[_rank] - top_left_1[i] + 1;
-                _bottom_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[2].insert(std::pair<int, int>(i, halo_size));
             }
         }
     }
@@ -316,13 +301,13 @@ void Partitioner::discover_neighbours()
                 && bottom_left_0[_rank] <= bottom_right_0[i]
                 && (top_left_1[_rank] - top_right_1[i] == 1)) {
                 int halo_size = bottom_right_0[i] - top_left_0[_rank] + 1;
-                _left_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[0].insert(std::pair<int, int>(i, halo_size));
             }
             if (bottom_left_0[_rank] >= top_right_0[i] && bottom_left_0[_rank] <= bottom_right_0[i]
                 && top_left_0[_rank] <= top_right_0[i]
                 && (bottom_left_1[_rank] - top_right_1[i] == 1)) {
                 int halo_size = bottom_left_0[_rank] - top_right_0[i] + 1;
-                _left_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[0].insert(std::pair<int, int>(i, halo_size));
             }
         }
     }
@@ -334,13 +319,13 @@ void Partitioner::discover_neighbours()
                 && bottom_right_0[_rank] >= bottom_left_0[i]
                 && (top_left_1[i] - top_right_1[_rank] == 1)) {
                 int halo_size = bottom_left_0[i] - top_right_0[_rank] + 1;
-                _right_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[1].insert(std::pair<int, int>(i, halo_size));
             }
             if (bottom_right_0[_rank] >= top_left_0[i] && bottom_right_0[_rank] <= bottom_left_0[i]
                 && top_right_0[_rank] <= top_left_0[i]
                 && (top_left_1[i] - top_right_1[_rank] == 1)) {
                 int halo_size = bottom_right_0[_rank] - top_left_0[i] + 1;
-                _right_neighbours.insert(std::pair<int, int>(i, halo_size));
+                _neighbours[1].insert(std::pair<int, int>(i, halo_size));
             }
         }
     }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -55,8 +55,8 @@ void Partitioner::save_mask(const std::string& filename) const
     // the C interface
     const int NDIMS = 2;
     int dimid[NDIMS];
-    NC_CHECK(nc_def_dim(nc_id, "x", _global_ext_0, &dimid[0]));
-    NC_CHECK(nc_def_dim(nc_id, "y", _global_ext_1, &dimid[1]));
+    NC_CHECK(nc_def_dim(nc_id, "x", _global_ext[0], &dimid[0]));
+    NC_CHECK(nc_def_dim(nc_id, "y", _global_ext[1], &dimid[1]));
 
     // Create variables
     int mask_nc_id;
@@ -105,8 +105,8 @@ void Partitioner::save_metadata(const std::string& filename) const
     // the C interface
     const int NDIMS = 2;
     int dimid_global[NDIMS];
-    NC_CHECK(nc_def_dim(nc_id, "NX", _global_ext_0, &dimid_global[0]));
-    NC_CHECK(nc_def_dim(nc_id, "NY", _global_ext_1, &dimid_global[1]));
+    NC_CHECK(nc_def_dim(nc_id, "NX", _global_ext[0], &dimid_global[0]));
+    NC_CHECK(nc_def_dim(nc_id, "NY", _global_ext[1], &dimid_global[1]));
 
     // Define dimensions in netCDF file
     int dimid;

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -100,7 +100,7 @@ void Partitioner::save_metadata(const std::string& filename) const
     }
 
     // There are two neighbours for each dimension
-    const int NNBRS = NDIMS * 2;
+    const int NNBRS = NDIMS * 2; // TODO: Why redeclared?
 
     // Prepare neighbour data
     std::vector<std::vector<int>> ids(NNBRS);

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -125,7 +125,7 @@ void Partitioner::save_metadata(const std::string& filename) const
     // Define variables in netCDF file
     int top_x_vid, top_y_vid;
     int cnt_x_vid, cnt_y_vid;
-    int top_num_vid, bottom_num_vid, left_num_vid, right_num_vid;
+    std::vector<int> num_vid(4);
     int top_ids_vid, bottom_ids_vid, left_ids_vid, right_ids_vid;
     int top_halos_vid, bottom_halos_vid, left_halos_vid, right_halos_vid;
     // Bounding boxes group
@@ -134,22 +134,22 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_def_var(bbox_gid, "domain_extent_x", NC_INT, 1, &dimid, &cnt_x_vid));
     NC_CHECK(nc_def_var(bbox_gid, "domain_extent_y", NC_INT, 1, &dimid, &cnt_y_vid));
     // Connectivity group
-    NC_CHECK(nc_def_var(connectivity_gid, "top_neighbours", NC_INT, 1, &dimid, &top_num_vid));
+    NC_CHECK(nc_def_var(connectivity_gid, "top_neighbours", NC_INT, 1, &dimid, &num_vid[3]));
     NC_CHECK(
         nc_def_var(connectivity_gid, "top_neighbour_ids", NC_INT, 1, &dimids[3], &top_ids_vid));
     NC_CHECK(
         nc_def_var(connectivity_gid, "top_neighbour_halos", NC_INT, 1, &dimids[3], &top_halos_vid));
-    NC_CHECK(nc_def_var(connectivity_gid, "bottom_neighbours", NC_INT, 1, &dimid, &bottom_num_vid));
+    NC_CHECK(nc_def_var(connectivity_gid, "bottom_neighbours", NC_INT, 1, &dimid, &num_vid[2]));
     NC_CHECK(nc_def_var(
         connectivity_gid, "bottom_neighbour_ids", NC_INT, 1, &dimids[2], &bottom_ids_vid));
     NC_CHECK(nc_def_var(
         connectivity_gid, "bottom_neighbour_halos", NC_INT, 1, &dimids[2], &bottom_halos_vid));
-    NC_CHECK(nc_def_var(connectivity_gid, "left_neighbours", NC_INT, 1, &dimid, &left_num_vid));
+    NC_CHECK(nc_def_var(connectivity_gid, "left_neighbours", NC_INT, 1, &dimid, &num_vid[0]));
     NC_CHECK(
         nc_def_var(connectivity_gid, "left_neighbour_ids", NC_INT, 1, &dimids[0], &left_ids_vid));
     NC_CHECK(nc_def_var(
         connectivity_gid, "left_neighbour_halos", NC_INT, 1, &dimids[0], &left_halos_vid));
-    NC_CHECK(nc_def_var(connectivity_gid, "right_neighbours", NC_INT, 1, &dimid, &right_num_vid));
+    NC_CHECK(nc_def_var(connectivity_gid, "right_neighbours", NC_INT, 1, &dimid, &num_vid[1]));
     NC_CHECK(
         nc_def_var(connectivity_gid, "right_neighbour_ids", NC_INT, 1, &dimids[1], &right_ids_vid));
     NC_CHECK(nc_def_var(
@@ -172,14 +172,10 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_var_par_access(bbox_gid, cnt_y_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_var1_int(bbox_gid, cnt_y_vid, &start, &_local_ext_1_new));
 
-    NC_CHECK(nc_var_par_access(connectivity_gid, top_num_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_var1_int(connectivity_gid, top_num_vid, &start, &num_neighbours[3]));
-    NC_CHECK(nc_var_par_access(connectivity_gid, bottom_num_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_var1_int(connectivity_gid, bottom_num_vid, &start, &num_neighbours[2]));
-    NC_CHECK(nc_var_par_access(connectivity_gid, left_num_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_var1_int(connectivity_gid, left_num_vid, &start, &num_neighbours[0]));
-    NC_CHECK(nc_var_par_access(connectivity_gid, right_num_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_var1_int(connectivity_gid, right_num_vid, &start, &num_neighbours[1]));
+    for (int idx = 0; idx < 4; idx++) {
+        NC_CHECK(nc_var_par_access(connectivity_gid, num_vid[idx], NC_COLLECTIVE));
+        NC_CHECK(nc_put_var1_int(connectivity_gid, num_vid[idx], &start, &num_neighbours[idx]));
+    }
 
     start = offsets[0];
     count = num_neighbours[0];

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -93,11 +93,11 @@ void Partitioner::save_metadata(const std::string& filename) const
         (int)bottom_ids.size(), (int)top_ids.size() };
 
     // Compute global dimensions
-    int top_dim, bottom_dim, left_dim, right_dim;
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[0], &left_dim, 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[1], &right_dim, 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[2], &bottom_dim, 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[3], &top_dim, 1, MPI_INT, MPI_SUM, _comm));
+    std::vector<int> dims = { 0, 0, 0, 0 };
+    CHECK_MPI(MPI_Allreduce(&num_neighbours[0], &dims[0], 1, MPI_INT, MPI_SUM, _comm));
+    CHECK_MPI(MPI_Allreduce(&num_neighbours[1], &dims[1], 1, MPI_INT, MPI_SUM, _comm));
+    CHECK_MPI(MPI_Allreduce(&num_neighbours[2], &dims[2], 1, MPI_INT, MPI_SUM, _comm));
+    CHECK_MPI(MPI_Allreduce(&num_neighbours[3], &dims[3], 1, MPI_INT, MPI_SUM, _comm));
 
     // Compute global offsets
     int top_offset = 0, bottom_offset = 0, left_offset = 0, right_offset = 0;
@@ -118,10 +118,10 @@ void Partitioner::save_metadata(const std::string& filename) const
     // Define dimensions in netCDF file
     int dimid, top_dimid, bottom_dimid, left_dimid, right_dimid;
     NC_CHECK(nc_def_dim(nc_id, "P", _num_procs, &dimid));
-    NC_CHECK(nc_def_dim(nc_id, "T", top_dim, &top_dimid));
-    NC_CHECK(nc_def_dim(nc_id, "B", bottom_dim, &bottom_dimid));
-    NC_CHECK(nc_def_dim(nc_id, "L", left_dim, &left_dimid));
-    NC_CHECK(nc_def_dim(nc_id, "R", right_dim, &right_dimid));
+    NC_CHECK(nc_def_dim(nc_id, "T", dims[3], &top_dimid));
+    NC_CHECK(nc_def_dim(nc_id, "B", dims[2], &bottom_dimid));
+    NC_CHECK(nc_def_dim(nc_id, "L", dims[0], &left_dimid));
+    NC_CHECK(nc_def_dim(nc_id, "R", dims[1], &right_dimid));
 
     // Define groups in netCDF file
     int bbox_gid, connectivity_gid;

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -84,11 +84,11 @@ void Partitioner::save_metadata(const std::string& filename) const
 
     // Prepare neighbour data
     std::vector<std::vector<int>> ids = { {}, {}, {}, {} };
-    std::vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    get_neighbours(ids[0], left_halos, 0);
-    get_neighbours(ids[1], right_halos, 1);
-    get_neighbours(ids[2], bottom_halos, 2);
-    get_neighbours(ids[3], top_halos, 3);
+    std::vector<std::vector<int>> halos = { {}, {}, {}, {} };
+    get_neighbours(ids[0], halos[0], 0);
+    get_neighbours(ids[1], halos[1], 1);
+    get_neighbours(ids[2], halos[2], 2);
+    get_neighbours(ids[3], halos[3], 3);
     std::vector<int> num_neighbours
         = { (int)ids[0].size(), (int)ids[1].size(), (int)ids[2].size(), (int)ids[3].size() };
 
@@ -192,27 +192,25 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_var_par_access(connectivity_gid, left_ids_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_vara_int(connectivity_gid, left_ids_vid, &start, &count, ids[0].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, left_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, left_halos_vid, &start, &count, left_halos.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, left_halos_vid, &start, &count, halos[0].data()));
     start = offsets[1];
     count = num_neighbours[1];
     NC_CHECK(nc_var_par_access(connectivity_gid, right_ids_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_vara_int(connectivity_gid, right_ids_vid, &start, &count, ids[1].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, right_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(
-        nc_put_vara_int(connectivity_gid, right_halos_vid, &start, &count, right_halos.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, right_halos_vid, &start, &count, halos[1].data()));
     start = offsets[2];
     count = num_neighbours[2];
     NC_CHECK(nc_var_par_access(connectivity_gid, bottom_ids_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_vara_int(connectivity_gid, bottom_ids_vid, &start, &count, ids[2].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, bottom_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(
-        nc_put_vara_int(connectivity_gid, bottom_halos_vid, &start, &count, bottom_halos.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, bottom_halos_vid, &start, &count, halos[2].data()));
     start = offsets[3];
     count = num_neighbours[3];
     NC_CHECK(nc_var_par_access(connectivity_gid, top_ids_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_vara_int(connectivity_gid, top_ids_vid, &start, &count, ids[3].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, top_halos_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, top_halos_vid, &start, &count, top_halos.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, top_halos_vid, &start, &count, halos[3].data()));
 
     NC_CHECK(nc_close(nc_id));
 }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -211,66 +211,55 @@ void Partitioner::discover_neighbours()
         bbox[3][1][p] = bbox[1][1][p] + bbox[2][1][p] - 1;
     }
 
-    // Find my left neighbours
-    for (int i = 0; i < _total_num_procs; i++) {
-        if (i != _rank) {
-            if (bbox[1][0][_rank] >= bbox[3][0][i] && bbox[1][0][_rank] <= bbox[2][0][i]
-                && bbox[0][0][_rank] <= bbox[2][0][i] && (bbox[1][1][_rank] - bbox[3][1][i] == 1)) {
-                int halo_size = bbox[2][0][i] - bbox[1][0][_rank] + 1;
-                _neighbours[0].insert(std::pair<int, int>(i, halo_size));
-            }
-            if (bbox[0][0][_rank] >= bbox[3][0][i] && bbox[0][0][_rank] <= bbox[2][0][i]
-                && bbox[1][0][_rank] <= bbox[3][0][i] && (bbox[0][1][_rank] - bbox[3][1][i] == 1)) {
-                int halo_size = bbox[0][0][_rank] - bbox[3][0][i] + 1;
-                _neighbours[0].insert(std::pair<int, int>(i, halo_size));
-            }
-        }
-    }
+    for (int p = 0; p < _total_num_procs; p++) {
+        if (p != _rank) {
 
-    // Find my right neighbours
-    for (int i = 0; i < _total_num_procs; i++) {
-        if (i != _rank) {
-            if (bbox[3][0][_rank] >= bbox[1][0][i] && bbox[3][0][_rank] <= bbox[0][0][i]
-                && bbox[2][0][_rank] >= bbox[0][0][i] && (bbox[1][1][i] - bbox[3][1][_rank] == 1)) {
-                int halo_size = bbox[0][0][i] - bbox[3][0][_rank] + 1;
-                _neighbours[1].insert(std::pair<int, int>(i, halo_size));
+            // Find my left neighbours
+            if (bbox[1][0][_rank] >= bbox[3][0][p] && bbox[1][0][_rank] <= bbox[2][0][p]
+                && bbox[0][0][_rank] <= bbox[2][0][p] && (bbox[1][1][_rank] - bbox[3][1][p] == 1)) {
+                int halo_size = bbox[2][0][p] - bbox[1][0][_rank] + 1;
+                _neighbours[0].insert(std::pair<int, int>(p, halo_size));
             }
-            if (bbox[2][0][_rank] >= bbox[1][0][i] && bbox[2][0][_rank] <= bbox[0][0][i]
-                && bbox[3][0][_rank] <= bbox[1][0][i] && (bbox[1][1][i] - bbox[3][1][_rank] == 1)) {
-                int halo_size = bbox[2][0][_rank] - bbox[1][0][i] + 1;
-                _neighbours[1].insert(std::pair<int, int>(i, halo_size));
+            if (bbox[0][0][_rank] >= bbox[3][0][p] && bbox[0][0][_rank] <= bbox[2][0][p]
+                && bbox[1][0][_rank] <= bbox[3][0][p] && (bbox[0][1][_rank] - bbox[3][1][p] == 1)) {
+                int halo_size = bbox[0][0][_rank] - bbox[3][0][p] + 1;
+                _neighbours[0].insert(std::pair<int, int>(p, halo_size));
             }
-        }
-    }
 
-    // Find my bottom neighbours
-    for (int i = 0; i < _total_num_procs; i++) {
-        if (i != _rank) {
-            if (bbox[0][1][_rank] >= bbox[1][1][i] && bbox[0][1][_rank] <= bbox[3][1][i]
-                && bbox[3][1][i] <= bbox[2][1][_rank] && (bbox[1][0][i] - bbox[0][0][_rank] == 1)) {
-                int halo_size = bbox[3][1][i] - bbox[0][1][_rank] + 1;
-                _neighbours[2].insert(std::pair<int, int>(i, halo_size));
+            // Find my right neighbours
+            if (bbox[3][0][_rank] >= bbox[1][0][p] && bbox[3][0][_rank] <= bbox[0][0][p]
+                && bbox[2][0][_rank] >= bbox[0][0][p] && (bbox[1][1][p] - bbox[3][1][_rank] == 1)) {
+                int halo_size = bbox[0][0][p] - bbox[3][0][_rank] + 1;
+                _neighbours[1].insert(std::pair<int, int>(p, halo_size));
             }
-            if (bbox[2][1][_rank] >= bbox[1][1][i] && bbox[2][1][_rank] <= bbox[3][1][i]
-                && bbox[1][1][i] >= bbox[0][1][_rank] && (bbox[3][0][i] - bbox[2][0][_rank] == 1)) {
-                int halo_size = bbox[2][1][_rank] - bbox[1][1][i] + 1;
-                _neighbours[2].insert(std::pair<int, int>(i, halo_size));
+            if (bbox[2][0][_rank] >= bbox[1][0][p] && bbox[2][0][_rank] <= bbox[0][0][p]
+                && bbox[3][0][_rank] <= bbox[1][0][p] && (bbox[1][1][p] - bbox[3][1][_rank] == 1)) {
+                int halo_size = bbox[2][0][_rank] - bbox[1][0][p] + 1;
+                _neighbours[1].insert(std::pair<int, int>(p, halo_size));
             }
-        }
-    }
 
-    // Find my top neighbours and their halo sizes
-    for (int i = 0; i < _total_num_procs; i++) {
-        if (i != _rank) {
-            if (bbox[1][1][_rank] >= bbox[0][1][i] && bbox[1][1][_rank] <= bbox[2][1][i]
-                && bbox[2][1][i] <= bbox[3][1][_rank] && (bbox[1][0][_rank] - bbox[0][0][i] == 1)) {
-                int halo_size = bbox[2][1][i] - bbox[1][1][_rank] + 1;
-                _neighbours[3].insert(std::pair<int, int>(i, halo_size));
+            // Find my bottom neighbours
+            if (bbox[0][1][_rank] >= bbox[1][1][p] && bbox[0][1][_rank] <= bbox[3][1][p]
+                && bbox[3][1][p] <= bbox[2][1][_rank] && (bbox[1][0][p] - bbox[0][0][_rank] == 1)) {
+                int halo_size = bbox[3][1][p] - bbox[0][1][_rank] + 1;
+                _neighbours[2].insert(std::pair<int, int>(p, halo_size));
             }
-            if (bbox[3][1][_rank] >= bbox[0][1][i] && bbox[3][1][_rank] <= bbox[2][1][i]
-                && bbox[0][1][i] >= bbox[1][1][_rank] && (bbox[3][0][_rank] - bbox[2][0][i] == 1)) {
-                int halo_size = bbox[3][1][_rank] - bbox[0][1][i] + 1;
-                _neighbours[3].insert(std::pair<int, int>(i, halo_size));
+            if (bbox[2][1][_rank] >= bbox[1][1][p] && bbox[2][1][_rank] <= bbox[3][1][p]
+                && bbox[1][1][p] >= bbox[0][1][_rank] && (bbox[3][0][p] - bbox[2][0][_rank] == 1)) {
+                int halo_size = bbox[2][1][_rank] - bbox[1][1][p] + 1;
+                _neighbours[2].insert(std::pair<int, int>(p, halo_size));
+            }
+
+            // Find my top neighbours and their halo sizes
+            if (bbox[1][1][_rank] >= bbox[0][1][p] && bbox[1][1][_rank] <= bbox[2][1][p]
+                && bbox[2][1][p] <= bbox[3][1][_rank] && (bbox[1][0][_rank] - bbox[0][0][p] == 1)) {
+                int halo_size = bbox[2][1][p] - bbox[1][1][_rank] + 1;
+                _neighbours[3].insert(std::pair<int, int>(p, halo_size));
+            }
+            if (bbox[3][1][_rank] >= bbox[0][1][p] && bbox[3][1][_rank] <= bbox[2][1][p]
+                && bbox[0][1][p] >= bbox[1][1][_rank] && (bbox[3][0][_rank] - bbox[2][0][p] == 1)) {
+                int halo_size = bbox[3][1][_rank] - bbox[0][1][p] + 1;
+                _neighbours[3].insert(std::pair<int, int>(p, halo_size));
             }
         }
     }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -30,11 +30,14 @@ void Partitioner::get_bounding_box(
     local_ext_1 = _local_ext_1_new;
 }
 
-void Partitioner::get_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes, int idx) const
+void Partitioner::get_neighbours(
+    std::vector<std::vector<int>>& ids, std::vector<std::vector<int>>& halo_sizes) const
 {
-    for (auto it = _neighbours[idx].begin(); it != _neighbours[idx].end(); ++it) {
-        ids.push_back(it->first);
-        halo_sizes.push_back(it->second);
+    for (int idx = 0; idx < 4; idx++) {
+        for (auto it = _neighbours[idx].begin(); it != _neighbours[idx].end(); ++it) {
+            ids[idx].push_back(it->first);
+            halo_sizes[idx].push_back(it->second);
+        }
     }
 }
 
@@ -85,10 +88,7 @@ void Partitioner::save_metadata(const std::string& filename) const
     // Prepare neighbour data
     std::vector<std::vector<int>> ids = { {}, {}, {}, {} };
     std::vector<std::vector<int>> halos = { {}, {}, {}, {} };
-    get_neighbours(ids[0], halos[0], 0);
-    get_neighbours(ids[1], halos[1], 1);
-    get_neighbours(ids[2], halos[2], 2);
-    get_neighbours(ids[3], halos[3], 3);
+    get_neighbours(ids, halos);
     std::vector<int> num_neighbours
         = { (int)ids[0].size(), (int)ids[1].size(), (int)ids[2].size(), (int)ids[3].size() };
 

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -30,36 +30,47 @@ void Partitioner::get_bounding_box(
     local_ext_1 = _local_ext_1_new;
 }
 
-void Partitioner::get_top_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
+void Partitioner::get_neighbours(
+    std::vector<int>& ids, std::vector<int>& halo_sizes, int dim, bool start) const
 {
-    for (auto it = _top_neighbours.begin(); it != _top_neighbours.end(); ++it) {
+    std::map<int, int> neighbours;
+    if (dim == 0) {
+        if (start) {
+            neighbours = _bottom_neighbours;
+        } else {
+            neighbours = _top_neighbours;
+        }
+    } else if (dim == 1) {
+        if (start) {
+            neighbours = _left_neighbours;
+        } else {
+            neighbours = _right_neighbours;
+        }
+    }
+    for (auto it = neighbours.begin(); it != neighbours.end(); ++it) {
         ids.push_back(it->first);
         halo_sizes.push_back(it->second);
     }
+}
+
+void Partitioner::get_top_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
+{
+    get_neighbours(ids, halo_sizes, 1, false);
 }
 
 void Partitioner::get_bottom_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
 {
-    for (auto it = _bottom_neighbours.begin(); it != _bottom_neighbours.end(); ++it) {
-        ids.push_back(it->first);
-        halo_sizes.push_back(it->second);
-    }
+    get_neighbours(ids, halo_sizes, 1, true);
 }
 
 void Partitioner::get_left_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
 {
-    for (auto it = _left_neighbours.begin(); it != _left_neighbours.end(); ++it) {
-        ids.push_back(it->first);
-        halo_sizes.push_back(it->second);
-    }
+    get_neighbours(ids, halo_sizes, 0, true);
 }
 
 void Partitioner::get_right_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
 {
-    for (auto it = _right_neighbours.begin(); it != _right_neighbours.end(); ++it) {
-        ids.push_back(it->first);
-        halo_sizes.push_back(it->second);
-    }
+    get_neighbours(ids, halo_sizes, 0, false);
 }
 
 void Partitioner::save_mask(const std::string& filename) const

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -190,44 +190,38 @@ Partitioner* Partitioner::Factory::create(
 void Partitioner::discover_neighbours()
 {
     // Gather bounding boxes for all processes
-    std::vector<std::vector<std::vector<std::vector<int>>>> bbox = {
-        {
-            { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
-            { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
-        },
-        {
-            { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
-            { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
-        }
-    };
+    std::vector<std::vector<std::vector<int>>> bbox = { {
+        { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
+        { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
+        { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
+        { std::vector<int>(_total_num_procs, -1), std::vector<int>(_total_num_procs, -1) },
+    } };
     for (int idx = 0; idx < 1; idx++) {
+        CHECK_MPI(
+            MPI_Allgather(&_global_new[idx], 1, MPI_INT, bbox[1][idx].data(), 1, MPI_INT, _comm));
         CHECK_MPI(MPI_Allgather(
-            &_global_new[idx], 1, MPI_INT, bbox[0][1][idx].data(), 1, MPI_INT, _comm));
-        CHECK_MPI(MPI_Allgather(
-            &_local_ext_new[idx], 1, MPI_INT, bbox[1][0][idx].data(), 1, MPI_INT, _comm));
+            &_local_ext_new[idx], 1, MPI_INT, bbox[2][idx].data(), 1, MPI_INT, _comm));
     }
     for (int p = 0; p < _total_num_procs; p++) {
-        bbox[0][0][0][p] = bbox[0][1][0][p] + bbox[1][0][0][p] - 1;
-        bbox[0][0][1][p] = bbox[0][1][1][p];
-        bbox[1][0][0][p] += bbox[0][1][0][p] - 1;
-        bbox[1][0][1][p] += bbox[0][1][1][p] - 1;
-        bbox[1][1][0][p] = bbox[0][1][0][p];
-        bbox[1][1][1][p] = bbox[0][1][1][p] + bbox[1][0][1][p] - 1;
+        bbox[0][0][p] = bbox[1][0][p] + bbox[2][0][p] - 1;
+        bbox[0][1][p] = bbox[1][1][p];
+        bbox[2][0][p] += bbox[1][0][p] - 1;
+        bbox[2][1][p] += bbox[1][1][p] - 1;
+        bbox[3][0][p] = bbox[1][0][p];
+        bbox[3][1][p] = bbox[1][1][p] + bbox[2][1][p] - 1;
     }
 
     // Find my left neighbours
     for (int i = 0; i < _total_num_procs; i++) {
         if (i != _rank) {
-            if (bbox[0][1][0][_rank] >= bbox[1][1][0][i] && bbox[0][1][0][_rank] <= bbox[1][0][0][i]
-                && bbox[0][0][0][_rank] <= bbox[1][0][0][i]
-                && (bbox[0][1][1][_rank] - bbox[1][1][1][i] == 1)) {
-                int halo_size = bbox[1][0][0][i] - bbox[0][1][0][_rank] + 1;
+            if (bbox[1][0][_rank] >= bbox[3][0][i] && bbox[1][0][_rank] <= bbox[2][0][i]
+                && bbox[0][0][_rank] <= bbox[2][0][i] && (bbox[1][1][_rank] - bbox[3][1][i] == 1)) {
+                int halo_size = bbox[2][0][i] - bbox[1][0][_rank] + 1;
                 _neighbours[0].insert(std::pair<int, int>(i, halo_size));
             }
-            if (bbox[0][0][0][_rank] >= bbox[1][1][0][i] && bbox[0][0][0][_rank] <= bbox[1][0][0][i]
-                && bbox[0][1][0][_rank] <= bbox[1][1][0][i]
-                && (bbox[0][0][1][_rank] - bbox[1][1][1][i] == 1)) {
-                int halo_size = bbox[0][0][0][_rank] - bbox[1][1][0][i] + 1;
+            if (bbox[0][0][_rank] >= bbox[3][0][i] && bbox[0][0][_rank] <= bbox[2][0][i]
+                && bbox[1][0][_rank] <= bbox[3][0][i] && (bbox[0][1][_rank] - bbox[3][1][i] == 1)) {
+                int halo_size = bbox[0][0][_rank] - bbox[3][0][i] + 1;
                 _neighbours[0].insert(std::pair<int, int>(i, halo_size));
             }
         }
@@ -236,16 +230,14 @@ void Partitioner::discover_neighbours()
     // Find my right neighbours
     for (int i = 0; i < _total_num_procs; i++) {
         if (i != _rank) {
-            if (bbox[1][1][0][_rank] >= bbox[0][1][0][i] && bbox[1][1][0][_rank] <= bbox[0][0][0][i]
-                && bbox[1][0][0][_rank] >= bbox[0][0][0][i]
-                && (bbox[0][1][1][i] - bbox[1][1][1][_rank] == 1)) {
-                int halo_size = bbox[0][0][0][i] - bbox[1][1][0][_rank] + 1;
+            if (bbox[3][0][_rank] >= bbox[1][0][i] && bbox[3][0][_rank] <= bbox[0][0][i]
+                && bbox[2][0][_rank] >= bbox[0][0][i] && (bbox[1][1][i] - bbox[3][1][_rank] == 1)) {
+                int halo_size = bbox[0][0][i] - bbox[3][0][_rank] + 1;
                 _neighbours[1].insert(std::pair<int, int>(i, halo_size));
             }
-            if (bbox[1][0][0][_rank] >= bbox[0][1][0][i] && bbox[1][0][0][_rank] <= bbox[0][0][0][i]
-                && bbox[1][1][0][_rank] <= bbox[0][1][0][i]
-                && (bbox[0][1][1][i] - bbox[1][1][1][_rank] == 1)) {
-                int halo_size = bbox[1][0][0][_rank] - bbox[0][1][0][i] + 1;
+            if (bbox[2][0][_rank] >= bbox[1][0][i] && bbox[2][0][_rank] <= bbox[0][0][i]
+                && bbox[3][0][_rank] <= bbox[1][0][i] && (bbox[1][1][i] - bbox[3][1][_rank] == 1)) {
+                int halo_size = bbox[2][0][_rank] - bbox[1][0][i] + 1;
                 _neighbours[1].insert(std::pair<int, int>(i, halo_size));
             }
         }
@@ -254,16 +246,14 @@ void Partitioner::discover_neighbours()
     // Find my bottom neighbours
     for (int i = 0; i < _total_num_procs; i++) {
         if (i != _rank) {
-            if (bbox[0][0][1][_rank] >= bbox[0][1][1][i] && bbox[0][0][1][_rank] <= bbox[1][1][1][i]
-                && bbox[1][1][1][i] <= bbox[1][0][1][_rank]
-                && (bbox[0][1][0][i] - bbox[0][0][0][_rank] == 1)) {
-                int halo_size = bbox[1][1][1][i] - bbox[0][0][1][_rank] + 1;
+            if (bbox[0][1][_rank] >= bbox[1][1][i] && bbox[0][1][_rank] <= bbox[3][1][i]
+                && bbox[3][1][i] <= bbox[2][1][_rank] && (bbox[1][0][i] - bbox[0][0][_rank] == 1)) {
+                int halo_size = bbox[3][1][i] - bbox[0][1][_rank] + 1;
                 _neighbours[2].insert(std::pair<int, int>(i, halo_size));
             }
-            if (bbox[1][0][1][_rank] >= bbox[0][1][1][i] && bbox[1][0][1][_rank] <= bbox[1][1][1][i]
-                && bbox[0][1][1][i] >= bbox[0][0][1][_rank]
-                && (bbox[1][1][0][i] - bbox[1][0][0][_rank] == 1)) {
-                int halo_size = bbox[1][0][1][_rank] - bbox[0][1][1][i] + 1;
+            if (bbox[2][1][_rank] >= bbox[1][1][i] && bbox[2][1][_rank] <= bbox[3][1][i]
+                && bbox[1][1][i] >= bbox[0][1][_rank] && (bbox[3][0][i] - bbox[2][0][_rank] == 1)) {
+                int halo_size = bbox[2][1][_rank] - bbox[1][1][i] + 1;
                 _neighbours[2].insert(std::pair<int, int>(i, halo_size));
             }
         }
@@ -272,16 +262,14 @@ void Partitioner::discover_neighbours()
     // Find my top neighbours and their halo sizes
     for (int i = 0; i < _total_num_procs; i++) {
         if (i != _rank) {
-            if (bbox[0][1][1][_rank] >= bbox[0][0][1][i] && bbox[0][1][1][_rank] <= bbox[1][0][1][i]
-                && bbox[1][0][1][i] <= bbox[1][1][1][_rank]
-                && (bbox[0][1][0][_rank] - bbox[0][0][0][i] == 1)) {
-                int halo_size = bbox[1][0][1][i] - bbox[0][1][1][_rank] + 1;
+            if (bbox[1][1][_rank] >= bbox[0][1][i] && bbox[1][1][_rank] <= bbox[2][1][i]
+                && bbox[2][1][i] <= bbox[3][1][_rank] && (bbox[1][0][_rank] - bbox[0][0][i] == 1)) {
+                int halo_size = bbox[2][1][i] - bbox[1][1][_rank] + 1;
                 _neighbours[3].insert(std::pair<int, int>(i, halo_size));
             }
-            if (bbox[1][1][1][_rank] >= bbox[0][0][1][i] && bbox[1][1][1][_rank] <= bbox[1][0][1][i]
-                && bbox[0][0][1][i] >= bbox[0][1][1][_rank]
-                && (bbox[1][1][0][_rank] - bbox[1][0][0][i] == 1)) {
-                int halo_size = bbox[1][1][1][_rank] - bbox[0][0][1][i] + 1;
+            if (bbox[3][1][_rank] >= bbox[0][1][i] && bbox[3][1][_rank] <= bbox[2][1][i]
+                && bbox[0][1][i] >= bbox[1][1][_rank] && (bbox[3][0][_rank] - bbox[2][0][i] == 1)) {
+                int halo_size = bbox[3][1][_rank] - bbox[0][1][i] + 1;
                 _neighbours[3].insert(std::pair<int, int>(i, halo_size));
             }
         }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -102,17 +102,11 @@ void Partitioner::save_metadata(const std::string& filename) const
     const int NNBRS = NDIMS * 2; // TODO: Why redeclared?
 
     // Prepare neighbour data
-    std::vector<std::vector<int>> ids(NNBRS);
-    std::vector<std::vector<int>> halos(NNBRS);
+    std::vector<std::vector<int>> ids(NNBRS), halos(NNBRS);
     get_neighbours(ids, halos);
-    std::vector<int> num_neighbours(NNBRS);
+    std::vector<int> num_neighbours(NNBRS), dims(NNBRS, 0), offsets(NNBRS, 0);
     for (int idx = 0; idx < NNBRS; idx++) {
         num_neighbours[idx] = (int)ids[idx].size();
-    }
-
-    // Compute global dimensions and offsets
-    std::vector<int> dims(NNBRS, 0), offsets(NNBRS, 0);
-    for (int idx = 0; idx < NNBRS; idx++) {
         CHECK_MPI(MPI_Allreduce(&num_neighbours[idx], &dims[idx], 1, MPI_INT, MPI_SUM, _comm));
         CHECK_MPI(MPI_Exscan(&num_neighbours[idx], &offsets[idx], 1, MPI_INT, MPI_SUM, _comm));
     }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -92,19 +92,12 @@ void Partitioner::save_metadata(const std::string& filename) const
     std::vector<int> num_neighbours
         = { (int)ids[0].size(), (int)ids[1].size(), (int)ids[2].size(), (int)ids[3].size() };
 
-    // Compute global dimensions
-    std::vector<int> dims = { 0, 0, 0, 0 };
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[0], &dims[0], 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[1], &dims[1], 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[2], &dims[2], 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Allreduce(&num_neighbours[3], &dims[3], 1, MPI_INT, MPI_SUM, _comm));
-
-    // Compute global offsets
-    std::vector<int> offsets = { 0, 0, 0, 0 };
-    CHECK_MPI(MPI_Exscan(&num_neighbours[0], &offsets[0], 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Exscan(&num_neighbours[1], &offsets[1], 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Exscan(&num_neighbours[2], &offsets[2], 1, MPI_INT, MPI_SUM, _comm));
-    CHECK_MPI(MPI_Exscan(&num_neighbours[3], &offsets[3], 1, MPI_INT, MPI_SUM, _comm));
+    // Compute global dimensions and offsets
+    std::vector<int> dims = { 0, 0, 0, 0 }, offsets = { 0, 0, 0, 0 };
+    for (int idx = 0; idx < 4; idx++) {
+        CHECK_MPI(MPI_Allreduce(&num_neighbours[idx], &dims[idx], 1, MPI_INT, MPI_SUM, _comm));
+        CHECK_MPI(MPI_Exscan(&num_neighbours[idx], &offsets[idx], 1, MPI_INT, MPI_SUM, _comm));
+    }
 
     // Create 2 dimensions
     // The values to be written are associated with the netCDF variable by

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -53,26 +53,6 @@ void Partitioner::get_neighbours(
     }
 }
 
-void Partitioner::get_top_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
-{
-    get_neighbours(ids, halo_sizes, 1, false);
-}
-
-void Partitioner::get_bottom_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
-{
-    get_neighbours(ids, halo_sizes, 1, true);
-}
-
-void Partitioner::get_left_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
-{
-    get_neighbours(ids, halo_sizes, 0, true);
-}
-
-void Partitioner::get_right_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const
-{
-    get_neighbours(ids, halo_sizes, 0, false);
-}
-
 void Partitioner::save_mask(const std::string& filename) const
 {
     // Use C API for parallel I/O
@@ -120,10 +100,10 @@ void Partitioner::save_metadata(const std::string& filename) const
     // Prepare neighbour data
     std::vector<int> top_ids, bottom_ids, left_ids, right_ids;
     std::vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    get_top_neighbours(top_ids, top_halos);
-    get_bottom_neighbours(bottom_ids, bottom_halos);
-    get_left_neighbours(left_ids, left_halos);
-    get_right_neighbours(right_ids, right_halos);
+    get_neighbours(left_ids, left_halos, 0, true);
+    get_neighbours(right_ids, right_halos, 0, false);
+    get_neighbours(bottom_ids, bottom_halos, 1, true);
+    get_neighbours(top_ids, top_halos, 1, false);
     int top_num_neighbours = top_ids.size();
     int bottom_num_neighbours = bottom_ids.size();
     int left_num_neighbours = left_ids.size();

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -83,14 +83,14 @@ void Partitioner::save_metadata(const std::string& filename) const
     NC_CHECK(nc_create_par(filename.c_str(), nc_mode, _comm, MPI_INFO_NULL, &nc_id));
 
     // Prepare neighbour data
-    std::vector<int> top_ids, bottom_ids, left_ids, right_ids;
+    std::vector<std::vector<int>> ids = { {}, {}, {}, {} };
     std::vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    get_neighbours(left_ids, left_halos, 0);
-    get_neighbours(right_ids, right_halos, 1);
-    get_neighbours(bottom_ids, bottom_halos, 2);
-    get_neighbours(top_ids, top_halos, 3);
-    std::vector<int> num_neighbours = { (int)left_ids.size(), (int)right_ids.size(),
-        (int)bottom_ids.size(), (int)top_ids.size() };
+    get_neighbours(ids[0], left_halos, 0);
+    get_neighbours(ids[1], right_halos, 1);
+    get_neighbours(ids[2], bottom_halos, 2);
+    get_neighbours(ids[3], top_halos, 3);
+    std::vector<int> num_neighbours
+        = { (int)ids[0].size(), (int)ids[1].size(), (int)ids[2].size(), (int)ids[3].size() };
 
     // Compute global dimensions
     std::vector<int> dims = { 0, 0, 0, 0 };
@@ -190,27 +190,27 @@ void Partitioner::save_metadata(const std::string& filename) const
     start = offsets[0];
     count = num_neighbours[0];
     NC_CHECK(nc_var_par_access(connectivity_gid, left_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, left_ids_vid, &start, &count, left_ids.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, left_ids_vid, &start, &count, ids[0].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, left_halos_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_vara_int(connectivity_gid, left_halos_vid, &start, &count, left_halos.data()));
     start = offsets[1];
     count = num_neighbours[1];
     NC_CHECK(nc_var_par_access(connectivity_gid, right_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, right_ids_vid, &start, &count, right_ids.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, right_ids_vid, &start, &count, ids[1].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, right_halos_vid, NC_COLLECTIVE));
     NC_CHECK(
         nc_put_vara_int(connectivity_gid, right_halos_vid, &start, &count, right_halos.data()));
     start = offsets[2];
     count = num_neighbours[2];
     NC_CHECK(nc_var_par_access(connectivity_gid, bottom_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, bottom_ids_vid, &start, &count, bottom_ids.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, bottom_ids_vid, &start, &count, ids[2].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, bottom_halos_vid, NC_COLLECTIVE));
     NC_CHECK(
         nc_put_vara_int(connectivity_gid, bottom_halos_vid, &start, &count, bottom_halos.data()));
     start = offsets[3];
     count = num_neighbours[3];
     NC_CHECK(nc_var_par_access(connectivity_gid, top_ids_vid, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(connectivity_gid, top_ids_vid, &start, &count, top_ids.data()));
+    NC_CHECK(nc_put_vara_int(connectivity_gid, top_ids_vid, &start, &count, ids[3].data()));
     NC_CHECK(nc_var_par_access(connectivity_gid, top_halos_vid, NC_COLLECTIVE));
     NC_CHECK(nc_put_vara_int(connectivity_gid, top_halos_vid, &start, &count, top_halos.data()));
 

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -111,6 +111,7 @@ protected:
     int _rank = -1; // Process rank
     int _total_num_procs = -1; // Total number of processes in communicator
     const int NDIMS = 2; // Number of dimensions
+    const int NNBRS = 2 * NDIMS; // Number of neighbours (two per dimension)
 
     // Total number of processes in each dimension
     std::vector<int> _num_procs = std::vector<int>(NDIMS, -1);
@@ -134,7 +135,7 @@ protected:
     std::vector<int> _proc_id = {};
 
     // Vector of maps of neighbours to their halo sizes after partitioning
-    std::vector<std::map<int, int>> _neighbours = { {}, {}, {}, {} };
+    std::vector<std::map<int, int>> _neighbours = std::vector<std::map<int, int>>(NNBRS);
 
 public:
     struct LIB_EXPORT Factory {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -69,30 +69,6 @@ public:
         std::vector<int>& ids, std::vector<int>& halo_sizes, int dim, bool start) const;
 
     /*!
-     * @brief Returns the MPI ranks and halo sizes of the top neighbours for this
-     * process after partitioning.
-     */
-    void get_top_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const;
-
-    /*!
-     * @brief Returns the MPI ranks and halo sizes of the bottom neighbours for
-     * this process after partitioning.
-     */
-    void get_bottom_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const;
-
-    /*!
-     * @brief Returns the MPI ranks and halo sizes of the left neighbours for this
-     * process after partitioning.
-     */
-    void get_left_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const;
-
-    /*!
-     * @brief Returns the MPI ranks and halo sizes of the right neighbours for this
-     * process after partitioning.
-     */
-    void get_right_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes) const;
-
-    /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a
      * NetCDF file.
      *

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -110,18 +110,31 @@ protected:
     MPI_Comm _comm; // MPI communicator
     int _rank = -1; // Process rank
     int _total_num_procs = -1; // Total number of processes in communicator
-    std::vector<int> _num_procs = { -1, -1 }; // Total number of processes in each dimension
-    std::vector<int> _global_ext = { 0, 0 }; // Global extents in each extension (blocking)
-    std::vector<int> _local_ext = { 0, 0 }; // Local extents in each dimension (original, blocking)
-    std::vector<int> _global = { -1, -1 }; /* Global coordinates of upper left corner (original,
-                                              blocking) */
-    std::vector<int> _local_ext_new = { 0, 0 }; /* Local extents in each dimension (after
-                                                   partitioning) */
-    std::vector<int> _global_new = { -1, -1 }; /* Global coordinates of upper left corner (after
-                                                  partitioning) */
-    std::vector<int> _proc_id = {}; // Process ids of partition (dense form)
-    std::vector<std::map<int, int>> _neighbours
-        = { {}, {}, {}, {} }; // Vector of maps of neighbours to their halo sizes after partitioning
+    const int NDIMS = 2; // Number of dimensions
+
+    // Total number of processes in each dimension
+    std::vector<int> _num_procs = std::vector<int>(NDIMS, -1);
+
+    // Global extents in each extension (blocking)
+    std::vector<int> _global_ext = std::vector<int>(NDIMS, 0);
+
+    // Local extents in each dimension (original, blocking)
+    std::vector<int> _local_ext = std::vector<int>(NDIMS, 0);
+
+    // Global coordinates of upper left corner (original, blocking)
+    std::vector<int> _global = std::vector<int>(NDIMS, -1);
+
+    // Local extents in each dimension (after partitioning)
+    std::vector<int> _local_ext_new = std::vector<int>(NDIMS, 0);
+
+    // Global coordinates of upper left corner (after partitioning)
+    std::vector<int> _global_new = std::vector<int>(NDIMS, -1);
+
+    // Process ids of partition (dense form)
+    std::vector<int> _proc_id = {};
+
+    // Vector of maps of neighbours to their halo sizes after partitioning
+    std::vector<std::map<int, int>> _neighbours = { {}, {}, {}, {} };
 
 public:
     struct LIB_EXPORT Factory {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -114,14 +114,11 @@ protected:
     int _num_procs_1 = -1; // Total number of processes in 2nd dimension
     int _global_ext_0 = 0; // Global extent in 1st extension (blocking)
     int _global_ext_1 = 0; // Global extent in 2nd extension (blocking)
-    int _local_ext_0 = 0; // Local extent in 1st dimension (original, blocking)
-    int _local_ext_1 = 0; // Local extent in 2nd dimension (original, blocking)
+    std::vector<int> _local_ext = { 0, 0 }; // Local extents in each dimension (original, blocking)
     std::vector<int> _global = { -1, -1 }; /* Global coordinates of upper left corner (original,
                                               blocking) */
-    int _local_ext_0_new = 0; /* Local extent in 1st dimension (after
-                                 partitioning) */
-    int _local_ext_1_new = 0; /* Local extent in 2nd dimension (after
-                                 partitioning) */
+    std::vector<int> _local_ext_new = { 0, 0 }; /* Local extents in each dimension (after
+                                                   partitioning) */
     std::vector<int> _global_new = { -1, -1 }; /* Global coordinates of upper left corner (after
                                                   partitioning) */
     std::vector<int> _proc_id = {}; // Process ids of partition (dense form)

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -113,6 +113,18 @@ protected:
     const int NDIMS = 2; // Number of dimensions
     const int NNBRS = 2 * NDIMS; // Number of neighbours (two per dimension)
 
+    // Letters used for each dimension
+    std::vector<std::string> dim_chars = { "x", "y" };
+
+    // Letters used for each direction
+    std::vector<std::string> dir_chars = { "L", "R", "B", "T" };
+
+    // Names used for each direction
+    std::vector<std::string> dir_names = { "left", "right", "bottom", "top" };
+
+    // Names used for global dimension extents
+    std::vector<std::string> global_extent_names = { "NX", "NY" };
+
     // Total number of processes in each dimension
     std::vector<int> _num_procs = std::vector<int>(NDIMS, -1);
 

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -56,6 +56,19 @@ public:
     void get_bounding_box(int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const;
 
     /*!
+     * @brief Returns the MPI ranks and halo sizes of the requested neighbours for this process
+     * after partitioning.
+     *
+     * @param ids MPI ranks of the neighbours
+     * @param halo_sizes Halo sizes of the neighbours
+     * @param dim Dimension to consider
+     * @param start If true, consider neighbours at the start of the dimension (left/bottom).
+     * Otherwise, consider those at the end (right/top).
+     */
+    void get_neighbours(
+        std::vector<int>& ids, std::vector<int>& halo_sizes, int dim, bool start) const;
+
+    /*!
      * @brief Returns the MPI ranks and halo sizes of the top neighbours for this
      * process after partitioning.
      */

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -109,9 +109,8 @@ protected:
 protected:
     MPI_Comm _comm; // MPI communicator
     int _rank = -1; // Process rank
-    int _num_procs = -1; // Total number of processes in communicator
-    int _num_procs_0 = -1; // Total number of processes in 1st dimension
-    int _num_procs_1 = -1; // Total number of processes in 2nd dimension
+    int _total_num_procs = -1; // Total number of processes in communicator
+    std::vector<int> _num_procs = { -1, -1 }; // Total number of processes in each dimension
     std::vector<int> _global_ext = { 0, 0 }; // Global extents in each extension (blocking)
     std::vector<int> _local_ext = { 0, 0 }; // Local extents in each dimension (original, blocking)
     std::vector<int> _global = { -1, -1 }; /* Global coordinates of upper left corner (original,

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -61,12 +61,9 @@ public:
      *
      * @param ids MPI ranks of the neighbours
      * @param halo_sizes Halo sizes of the neighbours
-     * @param dim Dimension to consider
-     * @param start If true, consider neighbours at the start of the dimension (left/bottom).
-     * Otherwise, consider those at the end (right/top).
+     * @param index 0=left, 1=right, 2=bottom, 3=top
      */
-    void get_neighbours(
-        std::vector<int>& ids, std::vector<int>& halo_sizes, int dim, bool start) const;
+    void get_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes, int index) const;
 
     /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a
@@ -132,14 +129,8 @@ protected:
     int _global_1_new = -1; /* Global coordinate in 2nd dimension of upper left
                                corner (after partitioning) */
     std::vector<int> _proc_id = {}; // Process ids of partition (dense form)
-    std::map<int, int> _top_neighbours
-        = {}; // Map of top neighbours to their halo sizes after partitioning
-    std::map<int, int> _bottom_neighbours
-        = {}; // Map of bottom neighbours to their halo sizes after partitioning
-    std::map<int, int> _right_neighbours
-        = {}; // Map of bottom neighbours to their halo sizes after partitioning
-    std::map<int, int> _left_neighbours
-        = {}; // Map of bottom neighbours to their halo sizes after partitioning
+    std::vector<std::map<int, int>> _neighbours
+        = { {}, {}, {}, {} }; // Vector of maps of neighbours to their halo sizes after partitioning
 
 public:
     struct LIB_EXPORT Factory {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -56,14 +56,14 @@ public:
     void get_bounding_box(int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const;
 
     /*!
-     * @brief Returns the MPI ranks and halo sizes of the requested neighbours for this process
-     * after partitioning.
+     * @brief Returns vectors containing the MPI ranks and halo sizes of the neighbours for this
+     * process after partitioning. The neighbours are ordered left, right, bottom, top.
      *
-     * @param ids MPI ranks of the neighbours
-     * @param halo_sizes Halo sizes of the neighbours
-     * @param index 0=left, 1=right, 2=bottom, 3=top
+     * @param ids MPI ranks of the neighbours for each direction
+     * @param halo_sizes Halo sizes of the neighbours for each direction
      */
-    void get_neighbours(std::vector<int>& ids, std::vector<int>& halo_sizes, int index) const;
+    void get_neighbours(
+        std::vector<std::vector<int>>& ids, std::vector<std::vector<int>>& halo_sizes) const;
 
     /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -116,18 +116,14 @@ protected:
     int _global_ext_1 = 0; // Global extent in 2nd extension (blocking)
     int _local_ext_0 = 0; // Local extent in 1st dimension (original, blocking)
     int _local_ext_1 = 0; // Local extent in 2nd dimension (original, blocking)
-    int _global_0 = -1; /* Global coordinate in 1st dimension of upper left corner
-                           (original, blocking) */
-    int _global_1 = -1; /* Global coordinate in 2nd dimension of upper left corner
-                           (original, blocking) */
+    std::vector<int> _global = { -1, -1 }; /* Global coordinates of upper left corner (original,
+                                              blocking) */
     int _local_ext_0_new = 0; /* Local extent in 1st dimension (after
                                  partitioning) */
     int _local_ext_1_new = 0; /* Local extent in 2nd dimension (after
                                  partitioning) */
-    int _global_0_new = -1; /* Global coordinate in 1st dimension of upper left
-                               corner (after partitioning) */
-    int _global_1_new = -1; /* Global coordinate in 2nd dimension of upper left
-                               corner (after partitioning) */
+    std::vector<int> _global_new = { -1, -1 }; /* Global coordinates of upper left corner (after
+                                                  partitioning) */
     std::vector<int> _proc_id = {}; // Process ids of partition (dense form)
     std::vector<std::map<int, int>> _neighbours
         = { {}, {}, {}, {} }; // Vector of maps of neighbours to their halo sizes after partitioning

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -112,8 +112,7 @@ protected:
     int _num_procs = -1; // Total number of processes in communicator
     int _num_procs_0 = -1; // Total number of processes in 1st dimension
     int _num_procs_1 = -1; // Total number of processes in 2nd dimension
-    int _global_ext_0 = 0; // Global extent in 1st extension (blocking)
-    int _global_ext_1 = 0; // Global extent in 2nd extension (blocking)
+    std::vector<int> _global_ext = { 0, 0 }; // Global extents in each extension (blocking)
     std::vector<int> _local_ext = { 0, 0 }; // Local extents in each dimension (original, blocking)
     std::vector<int> _global = { -1, -1 }; /* Global coordinates of upper left corner (original,
                                               blocking) */

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -95,8 +95,8 @@ void ZoltanPartitioner::partition(Grid& grid)
     // Load initial grid state
     _num_procs_0 = grid.get_num_procs_0();
     _num_procs_1 = grid.get_num_procs_1();
-    _global_ext_0 = grid.get_global_ext_0();
-    _global_ext_1 = grid.get_global_ext_1();
+    _global_ext[0] = grid.get_global_ext_0();
+    _global_ext[1] = grid.get_global_ext_1();
     int blk_factor_0 = grid.get_blk_factor_0();
     int blk_factor_1 = grid.get_blk_factor_1();
     grid.get_bounding_box(_global[0], _global[1], _local_ext[0], _local_ext[1]);
@@ -184,8 +184,8 @@ void ZoltanPartitioner::partition(Grid& grid)
         _global_new[0] = (xmin == -DBL_MAX) ? 0 : std::ceil(xmin);
         _global_new[1] = (ymin == -DBL_MAX) ? 0 : std::ceil(ymin);
         int global_0_lower, global_1_lower;
-        global_0_lower = (xmax == DBL_MAX) ? _global_ext_0 : std::ceil(xmax);
-        global_1_lower = (ymax == DBL_MAX) ? _global_ext_1 : std::ceil(ymax);
+        global_0_lower = (xmax == DBL_MAX) ? _global_ext[0] : std::ceil(xmax);
+        global_1_lower = (ymax == DBL_MAX) ? _global_ext[1] : std::ceil(ymax);
         _local_ext_new[0] = global_0_lower - _global_new[0];
         _local_ext_new[1] = global_1_lower - _global_new[1];
     } else {

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -93,15 +93,15 @@ ZoltanPartitioner* ZoltanPartitioner::create(MPI_Comm comm, int argc, char** arg
 void ZoltanPartitioner::partition(Grid& grid)
 {
     // Load initial grid state
-    _num_procs_0 = grid.get_num_procs_0();
-    _num_procs_1 = grid.get_num_procs_1();
+    _num_procs[0] = grid.get_num_procs_0();
+    _num_procs[1] = grid.get_num_procs_1();
     _global_ext[0] = grid.get_global_ext_0();
     _global_ext[1] = grid.get_global_ext_1();
     int blk_factor_0 = grid.get_blk_factor_0();
     int blk_factor_1 = grid.get_blk_factor_1();
     grid.get_bounding_box(_global[0], _global[1], _local_ext[0], _local_ext[1]);
 
-    if (_num_procs == 1) {
+    if (_total_num_procs == 1) {
         _global_new[0] = _global[0];
         _global_new[1] = _global[1];
         _local_ext_new[0] = _local_ext[0];

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -99,16 +99,16 @@ void ZoltanPartitioner::partition(Grid& grid)
     _global_ext_1 = grid.get_global_ext_1();
     int blk_factor_0 = grid.get_blk_factor_0();
     int blk_factor_1 = grid.get_blk_factor_1();
-    grid.get_bounding_box(_global_0, _global_1, _local_ext_0, _local_ext_1);
+    grid.get_bounding_box(_global[0], _global[1], _local_ext_0, _local_ext_1);
 
     if (_num_procs == 1) {
-        _global_0_new = _global_0;
-        _global_1_new = _global_1;
+        _global_new[0] = _global[0];
+        _global_new[1] = _global[1];
         _local_ext_0_new = _local_ext_0;
         _local_ext_1_new = _local_ext_1;
         // Adapt to blocking
-        _global_0_new *= blk_factor_0;
-        _global_1_new *= blk_factor_1;
+        _global_new[0] *= blk_factor_0;
+        _global_new[1] *= blk_factor_1;
         _local_ext_0_new *= blk_factor_0;
         _local_ext_1_new *= blk_factor_1;
 
@@ -181,30 +181,30 @@ void ZoltanPartitioner::partition(Grid& grid)
         double xmin, ymin, zmin;
         double xmax, ymax, zmax;
         _zoltan->RCB_Box(_rank, ndim, xmin, ymin, zmin, xmax, ymax, zmax);
-        _global_0_new = (xmin == -DBL_MAX) ? 0 : std::ceil(xmin);
-        _global_1_new = (ymin == -DBL_MAX) ? 0 : std::ceil(ymin);
+        _global_new[0] = (xmin == -DBL_MAX) ? 0 : std::ceil(xmin);
+        _global_new[1] = (ymin == -DBL_MAX) ? 0 : std::ceil(ymin);
         int global_0_lower, global_1_lower;
         global_0_lower = (xmax == DBL_MAX) ? _global_ext_0 : std::ceil(xmax);
         global_1_lower = (ymax == DBL_MAX) ? _global_ext_1 : std::ceil(ymax);
-        _local_ext_0_new = global_0_lower - _global_0_new;
-        _local_ext_1_new = global_1_lower - _global_1_new;
+        _local_ext_0_new = global_0_lower - _global_new[0];
+        _local_ext_1_new = global_1_lower - _global_new[1];
     } else {
-        _global_0_new = _global_0;
-        _global_1_new = _global_1;
+        _global_new[0] = _global[0];
+        _global_new[1] = _global[1];
         _local_ext_0_new = _local_ext_0;
         _local_ext_1_new = _local_ext_1;
     }
 
     // Adapt to blocking
-    _global_0_new *= blk_factor_0;
-    _global_1_new *= blk_factor_1;
+    _global_new[0] *= blk_factor_0;
+    _global_new[1] *= blk_factor_1;
     _local_ext_0_new *= blk_factor_0;
     _local_ext_1_new *= blk_factor_1;
-    if (_global_0_new + _local_ext_0_new > grid.get_global_ext_orig_0()) {
-        _local_ext_0_new = grid.get_global_ext_orig_0() - _global_0_new;
+    if (_global_new[0] + _local_ext_0_new > grid.get_global_ext_orig_0()) {
+        _local_ext_0_new = grid.get_global_ext_orig_0() - _global_new[0];
     }
-    if (_global_1_new + _local_ext_1_new > grid.get_global_ext_orig_1()) {
-        _local_ext_1_new = grid.get_global_ext_orig_1() - _global_1_new;
+    if (_global_new[1] + _local_ext_1_new > grid.get_global_ext_orig_1()) {
+        _local_ext_1_new = grid.get_global_ext_orig_1() - _global_new[1];
     }
 
     // Find my neighbours

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -97,20 +97,17 @@ void ZoltanPartitioner::partition(Grid& grid)
     _num_procs[1] = grid.get_num_procs_1();
     _global_ext[0] = grid.get_global_ext_0();
     _global_ext[1] = grid.get_global_ext_1();
-    int blk_factor_0 = grid.get_blk_factor_0();
-    int blk_factor_1 = grid.get_blk_factor_1();
+    std::vector<int> blk_factors = { grid.get_blk_factor_0(), grid.get_blk_factor_1() };
     grid.get_bounding_box(_global[0], _global[1], _local_ext[0], _local_ext[1]);
 
     if (_total_num_procs == 1) {
-        _global_new[0] = _global[0];
-        _global_new[1] = _global[1];
-        _local_ext_new[0] = _local_ext[0];
-        _local_ext_new[1] = _local_ext[1];
-        // Adapt to blocking
-        _global_new[0] *= blk_factor_0;
-        _global_new[1] *= blk_factor_1;
-        _local_ext_new[0] *= blk_factor_0;
-        _local_ext_new[1] *= blk_factor_1;
+        for (int idx = 0; idx < 2; idx++) {
+            _global_new[idx] = _global[idx];
+            _local_ext_new[idx] = _local_ext[idx];
+            // Adapt to blocking
+            _global_new[idx] *= blk_factors[idx];
+            _local_ext_new[idx] *= blk_factors[idx];
+        }
 
         if (grid.get_num_objects() != grid.get_num_nonzero_objects()) {
             const int* land_mask = grid.get_land_mask();
@@ -178,33 +175,30 @@ void ZoltanPartitioner::partition(Grid& grid)
     // Find new bounding boxes for each process
     if (changes == 1) {
         int ndim;
-        double xmin, ymin, zmin;
-        double xmax, ymax, zmax;
-        _zoltan->RCB_Box(_rank, ndim, xmin, ymin, zmin, xmax, ymax, zmax);
-        _global_new[0] = (xmin == -DBL_MAX) ? 0 : std::ceil(xmin);
-        _global_new[1] = (ymin == -DBL_MAX) ? 0 : std::ceil(ymin);
-        int global_0_lower, global_1_lower;
-        global_0_lower = (xmax == DBL_MAX) ? _global_ext[0] : std::ceil(xmax);
-        global_1_lower = (ymax == DBL_MAX) ? _global_ext[1] : std::ceil(ymax);
-        _local_ext_new[0] = global_0_lower - _global_new[0];
-        _local_ext_new[1] = global_1_lower - _global_new[1];
+        double mins[3];
+        double maxs[3];
+        _zoltan->RCB_Box(_rank, ndim, mins[0], mins[1], mins[2], maxs[0], maxs[1], maxs[2]);
+        for (int idx = 0; idx < 2; idx++) {
+            _global_new[idx] = (mins[idx] == -DBL_MAX) ? 0 : std::ceil(mins[idx]);
+            int global_lower = (maxs[idx] == DBL_MAX) ? _global_ext[idx] : std::ceil(maxs[idx]);
+            _local_ext_new[idx] = global_lower - _global_new[idx];
+        }
     } else {
-        _global_new[0] = _global[0];
-        _global_new[1] = _global[1];
-        _local_ext_new[0] = _local_ext[0];
-        _local_ext_new[1] = _local_ext[1];
+        for (int idx = 0; idx < 2; idx++) {
+            _global_new[idx] = _global[idx];
+            _local_ext_new[idx] = _local_ext[idx];
+        }
     }
 
     // Adapt to blocking
-    _global_new[0] *= blk_factor_0;
-    _global_new[1] *= blk_factor_1;
-    _local_ext_new[0] *= blk_factor_0;
-    _local_ext_new[1] *= blk_factor_1;
-    if (_global_new[0] + _local_ext_new[0] > grid.get_global_ext_orig_0()) {
-        _local_ext_new[0] = grid.get_global_ext_orig_0() - _global_new[0];
-    }
-    if (_global_new[1] + _local_ext_new[1] > grid.get_global_ext_orig_1()) {
-        _local_ext_new[1] = grid.get_global_ext_orig_1() - _global_new[1];
+    std::vector<int> global_ext_orig
+        = { grid.get_global_ext_orig_0(), grid.get_global_ext_orig_1() };
+    for (int idx = 0; idx < 2; idx++) {
+        _global_new[idx] *= blk_factors[idx];
+        _local_ext_new[idx] *= blk_factors[idx];
+        if (_global_new[idx] + _local_ext_new[idx] > global_ext_orig[idx]) {
+            _local_ext_new[idx] = global_ext_orig[idx] - _global_new[idx];
+        }
     }
 
     // Find my neighbours

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -99,18 +99,18 @@ void ZoltanPartitioner::partition(Grid& grid)
     _global_ext_1 = grid.get_global_ext_1();
     int blk_factor_0 = grid.get_blk_factor_0();
     int blk_factor_1 = grid.get_blk_factor_1();
-    grid.get_bounding_box(_global[0], _global[1], _local_ext_0, _local_ext_1);
+    grid.get_bounding_box(_global[0], _global[1], _local_ext[0], _local_ext[1]);
 
     if (_num_procs == 1) {
         _global_new[0] = _global[0];
         _global_new[1] = _global[1];
-        _local_ext_0_new = _local_ext_0;
-        _local_ext_1_new = _local_ext_1;
+        _local_ext_new[0] = _local_ext[0];
+        _local_ext_new[1] = _local_ext[1];
         // Adapt to blocking
         _global_new[0] *= blk_factor_0;
         _global_new[1] *= blk_factor_1;
-        _local_ext_0_new *= blk_factor_0;
-        _local_ext_1_new *= blk_factor_1;
+        _local_ext_new[0] *= blk_factor_0;
+        _local_ext_new[1] *= blk_factor_1;
 
         if (grid.get_num_objects() != grid.get_num_nonzero_objects()) {
             const int* land_mask = grid.get_land_mask();
@@ -186,25 +186,25 @@ void ZoltanPartitioner::partition(Grid& grid)
         int global_0_lower, global_1_lower;
         global_0_lower = (xmax == DBL_MAX) ? _global_ext_0 : std::ceil(xmax);
         global_1_lower = (ymax == DBL_MAX) ? _global_ext_1 : std::ceil(ymax);
-        _local_ext_0_new = global_0_lower - _global_new[0];
-        _local_ext_1_new = global_1_lower - _global_new[1];
+        _local_ext_new[0] = global_0_lower - _global_new[0];
+        _local_ext_new[1] = global_1_lower - _global_new[1];
     } else {
         _global_new[0] = _global[0];
         _global_new[1] = _global[1];
-        _local_ext_0_new = _local_ext_0;
-        _local_ext_1_new = _local_ext_1;
+        _local_ext_new[0] = _local_ext[0];
+        _local_ext_new[1] = _local_ext[1];
     }
 
     // Adapt to blocking
     _global_new[0] *= blk_factor_0;
     _global_new[1] *= blk_factor_1;
-    _local_ext_0_new *= blk_factor_0;
-    _local_ext_1_new *= blk_factor_1;
-    if (_global_new[0] + _local_ext_0_new > grid.get_global_ext_orig_0()) {
-        _local_ext_0_new = grid.get_global_ext_orig_0() - _global_new[0];
+    _local_ext_new[0] *= blk_factor_0;
+    _local_ext_new[1] *= blk_factor_1;
+    if (_global_new[0] + _local_ext_new[0] > grid.get_global_ext_orig_0()) {
+        _local_ext_new[0] = grid.get_global_ext_orig_0() - _global_new[0];
     }
-    if (_global_new[1] + _local_ext_1_new > grid.get_global_ext_orig_1()) {
-        _local_ext_1_new = grid.get_global_ext_orig_1() - _global_new[1];
+    if (_global_new[1] + _local_ext_new[1] > grid.get_global_ext_orig_1()) {
+        _local_ext_new[1] = grid.get_global_ext_orig_1() - _global_new[1];
     }
 
     // Find my neighbours

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -63,10 +63,10 @@ int main(int argc, char* argv[])
     // Retrieve neighbours
     vector<int> top_ids, bottom_ids, left_ids, right_ids;
     vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    partitioner->get_neighbours(left_ids, left_halos, 0, true);
-    partitioner->get_neighbours(right_ids, right_halos, 1, false);
-    partitioner->get_neighbours(bottom_ids, bottom_halos, 1, true);
-    partitioner->get_neighbours(top_ids, top_halos, 1, false);
+    partitioner->get_neighbours(left_ids, left_halos, 0);
+    partitioner->get_neighbours(right_ids, right_halos, 1);
+    partitioner->get_neighbours(bottom_ids, bottom_halos, 2);
+    partitioner->get_neighbours(top_ids, top_halos, 3);
 
     // MPI ranks of neighbours in order: top, bottom, left, right
     vector<int> ids(top_ids);

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -62,11 +62,11 @@ int main(int argc, char* argv[])
 
     // Retrieve neighbours
     vector<vector<int>> id_vec = { {}, {}, {}, {} };
-    vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    partitioner->get_neighbours(id_vec[0], left_halos, 0);
-    partitioner->get_neighbours(id_vec[1], right_halos, 1);
-    partitioner->get_neighbours(id_vec[2], bottom_halos, 2);
-    partitioner->get_neighbours(id_vec[3], top_halos, 3);
+    vector<vector<int>> halos = { {}, {}, {}, {} };
+    partitioner->get_neighbours(id_vec[0], halos[0], 0);
+    partitioner->get_neighbours(id_vec[1], halos[1], 1);
+    partitioner->get_neighbours(id_vec[2], halos[2], 2);
+    partitioner->get_neighbours(id_vec[3], halos[3], 3);
 
     // MPI ranks of neighbours in order: top, bottom, left, right
     vector<int> ids(id_vec[3]);
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
 
     // Top neighbours
     for (int i = 0; i < static_cast<int>(id_vec[3].size()); i++) {
-        int subsizes[ndims] = { 1, top_halos[i] };
+        int subsizes[ndims] = { 1, halos[3][i] };
 
         int send_top_start[ndims] = { 1, offset + 1 };
         MPI_Type_create_subarray(
@@ -141,14 +141,14 @@ int main(int argc, char* argv[])
         rcounts[cnt] = 1;
         rdispls[cnt] = 0;
 
-        offset += top_halos[i];
+        offset += halos[3][i];
         cnt++;
     }
 
     // Bottom neighbours
     offset = 0;
     for (int i = 0; i < static_cast<int>(id_vec[2].size()); i++) {
-        int subsizes[ndims] = { 1, bottom_halos[i] };
+        int subsizes[ndims] = { 1, halos[2][i] };
 
         int send_bottom_start[ndims] = { local_ext_0, offset + 1 };
         MPI_Type_create_subarray(
@@ -166,14 +166,14 @@ int main(int argc, char* argv[])
         rcounts[cnt] = 1;
         rdispls[cnt] = 0;
 
-        offset += bottom_halos[i];
+        offset += halos[2][i];
         cnt++;
     }
 
     // Left neighbours
     offset = 0;
     for (int i = 0; i < static_cast<int>(id_vec[0].size()); i++) {
-        int subsizes[ndims] = { left_halos[i], 1 };
+        int subsizes[ndims] = { halos[0][i], 1 };
 
         int send_left_start[ndims] = { offset + 1, 1 };
         MPI_Type_create_subarray(
@@ -191,14 +191,14 @@ int main(int argc, char* argv[])
         rcounts[cnt] = 1;
         rdispls[cnt] = 0;
 
-        offset += left_halos[i];
+        offset += halos[0][i];
         cnt++;
     }
 
     // Right neighbours
     offset = 0;
     for (int i = 0; i < static_cast<int>(id_vec[1].size()); i++) {
-        int subsizes[ndims] = { right_halos[i], 1 };
+        int subsizes[ndims] = { halos[1][i], 1 };
 
         int send_right_start[ndims] = { offset + 1, local_ext_1 };
         MPI_Type_create_subarray(
@@ -216,7 +216,7 @@ int main(int argc, char* argv[])
         rcounts[cnt] = 1;
         rdispls[cnt] = 0;
 
-        offset += right_halos[i];
+        offset += halos[1][i];
         cnt++;
     }
 

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -63,10 +63,7 @@ int main(int argc, char* argv[])
     // Retrieve neighbours
     vector<vector<int>> ids = { {}, {}, {}, {} };
     vector<vector<int>> halos = { {}, {}, {}, {} };
-    partitioner->get_neighbours(ids[0], halos[0], 0);
-    partitioner->get_neighbours(ids[1], halos[1], 1);
-    partitioner->get_neighbours(ids[2], halos[2], 2);
-    partitioner->get_neighbours(ids[3], halos[3], 3);
+    partitioner->get_neighbours(ids, halos);
 
     // MPI ranks of neighbours in order: top, bottom, left, right
     vector<int> ids_tblr(ids[3]);

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -63,10 +63,10 @@ int main(int argc, char* argv[])
     // Retrieve neighbours
     vector<int> top_ids, bottom_ids, left_ids, right_ids;
     vector<int> top_halos, bottom_halos, left_halos, right_halos;
-    partitioner->get_top_neighbours(top_ids, top_halos);
-    partitioner->get_bottom_neighbours(bottom_ids, bottom_halos);
-    partitioner->get_left_neighbours(left_ids, left_halos);
-    partitioner->get_right_neighbours(right_ids, right_halos);
+    partitioner->get_neighbours(left_ids, left_halos, 0, true);
+    partitioner->get_neighbours(right_ids, right_halos, 1, false);
+    partitioner->get_neighbours(bottom_ids, bottom_halos, 1, true);
+    partitioner->get_neighbours(top_ids, top_halos, 1, false);
 
     // MPI ranks of neighbours in order: top, bottom, left, right
     vector<int> ids(top_ids);


### PR DESCRIPTION
A first refactoring of the `Partitioner` class.

#### Main changes

* Combine `get_top_neighbours`, `get_bottom_neighbours`, etc. into a single method.
* Combine various variable pairs with names including `_0` or `_1` into vectors.
* Use vectors for ids, halos, offsets, etc. across the four directions (left, right, bottom, top) and loop over the directions for conciseness.

These changes cut down duplication and will make it easier to switch direction orderings.


#### Future work

Some of this gets propagated through to the `ZoltanPartitioner` class but it will need further refactoring. There is also further refactoring to be done handling the bounding boxes.