### PR TITLE
feat: add halo start indices to partition_metadata

### DIFF
--- a/DomainUtils.cpp
+++ b/DomainUtils.cpp
@@ -9,24 +9,27 @@
 #include <algorithm>
 #include <iostream>
 
-int domainOverlap(const Domain d1, const Domain d2, const char dir)
+int Domain::get_width() const { return p2.x - p1.x; }
+int Domain::get_height() const { return p2.y - p1.y; }
+
+int domain_overlap(const Domain d1, const Domain d2, const Edge edge)
 {
     int overlap = 0;
-    if (dir == 'x') {
+    if (edge == TOP || edge == BOTTOM) {
         // check that at least one of the points in domain 1 overlap with domain 2 in the
         // x-direction
         if (d1.p2.x >= d2.p1.x && d1.p1.x <= d2.p2.x) {
             overlap = std::min(d1.p2.x, d2.p2.x) - std::max(d1.p1.x, d2.p1.x);
         }
-    } else if (dir == 'y') {
+    } else if (edge == LEFT || edge == RIGHT) {
         // check that at least one of the points in domain 1 overlap with domain 2 in the
         // y-direction
         if (d1.p2.y >= d2.p1.y && d1.p1.y <= d2.p2.y) {
             overlap = std::min(d1.p2.y, d2.p2.y) - std::max(d1.p1.y, d2.p1.y);
         }
     } else {
-        std::cerr << "ERROR: Unrecognised direction. Please use 'x' or 'y'." << std::endl;
-        return 1;
+        std::cerr << "ERROR: edge must be LEFT, RIGHT, BOTTOM, TOP." << std::endl;
+        exit(EXIT_FAILURE);
     }
     return overlap;
 }

--- a/DomainUtils.hpp
+++ b/DomainUtils.hpp
@@ -8,6 +8,11 @@
 #ifndef DOMAINUTILS_HPP
 #define DOMAINUTILS_HPP
 
+#include <array>
+
+enum Edge { LEFT, RIGHT, BOTTOM, TOP, N_EDGE };
+static constexpr std::array<Edge, N_EDGE> edges = { LEFT, RIGHT, BOTTOM, TOP };
+
 /*!
  * @brief 2D point structs. Points can be used to construct Domains.
  */
@@ -30,19 +35,26 @@ struct Point {
  */
 struct Domain {
     Point p1, p2;
+    /*!
+     * @brief return width of domain
+     */
+    int get_width() const;
+    /*!
+     * @brief return height of domain
+     */
+    int get_height() const;
 };
 
 /*!
- * @brief Compute the overlap between two domains. Will return zero if domains
- * do not overlap.
+ * @brief Compute the overlap between two domains. Will return zero if domains do not overlap.
  *
- * Note that this doesn't check if two domains are neighbours, just that they
- * overlap in the x or y direction.
+ * Note that this doesn't check if two domains are neighbours, just that they overlap in the x or y
+ * direction.
  *
  * @param d1 First Domain
  * @param d2 Second Domain
  * @param dir direction to find overlap ('x' or 'y')
  */
-int domainOverlap(const Domain d1, const Domain d2, const char dir);
+int domain_overlap(const Domain d1, const Domain d2, const Edge edge);
 
 #endif /* DOMAINUTILS_HPP */

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -56,11 +56,15 @@ int Partitioner::halo_start(const Domain d1, const Domain d2, const Edge edge)
 {
     int start = 0;
     if (edge == TOP) {
-        // offset between domains
+        // dx is the offset between domains
         int dx = std::max(d1.p1.x, d2.p1.x) - d2.p1.x;
+        // in this case the start location is equivalent
         start = dx;
     } else if (edge == BOTTOM) {
+        // dx is the offset between domains
         int dx = std::max(d1.p1.x, d2.p1.x) - d2.p1.x;
+        // start will be in last row in the 2D-domain, therefore we need to account for (ny-1) * nx
+        // elements that come before the offset dx.
         start = (d2.get_height() - 1) * d2.get_width() + dx;
     } else if (edge == LEFT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d2.p1.y;

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -24,50 +24,32 @@ bool Partitioner::is_neighbour(
         // Check if TOP neighbour i.e., the bottom of domain d2 must match the top of domain d1.
         // The logic for the other edges is essentially the same.
         if (is_py) {
-            if (d1.p2.y == d2.p1.y + _global_ext[1]) {
-                return true;
-            }
+            return d1.p2.y == d2.p1.y + _global_ext[1];
         } else {
-            if (d1.p2.y == d2.p1.y) {
-                return true;
-            }
+            return d1.p2.y == d2.p1.y;
         }
     } else if (edge == BOTTOM) {
         if (is_py) {
-            if (d1.p1.y == d2.p2.y - _global_ext[1]) {
-                return true;
-            }
+            return d1.p1.y == d2.p2.y - _global_ext[1];
         } else {
-            if (d1.p1.y == d2.p2.y) {
-                return true;
-            }
+            return d1.p1.y == d2.p2.y;
         }
     } else if (edge == LEFT) {
         if (is_px) {
-            if (d1.p1.x == d2.p2.x - _global_ext[0]) {
-                return true;
-            }
+            return d1.p1.x == d2.p2.x - _global_ext[0];
         } else {
-            if (d1.p1.x == d2.p2.x) {
-                return true;
-            }
+            return d1.p1.x == d2.p2.x;
         }
     } else if (edge == RIGHT) {
         if (is_px) {
-            if (d1.p2.x == d2.p1.x + _global_ext[0]) {
-                return true;
-            }
+            return d1.p2.x == d2.p1.x + _global_ext[0];
         } else {
-
-            if (d1.p2.x == d2.p1.x) {
-                return true;
-            }
+            return d1.p2.x == d2.p1.x;
         }
     } else {
         std::cerr << "ERROR: edge must be LEFT, RIGHT, BOTTOM, TOP." << std::endl;
         exit(EXIT_FAILURE);
     }
-    return false;
 }
 
 int Partitioner::halo_start(const Domain d1, const Domain d2, const Edge edge)

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -197,7 +197,7 @@ private:
     /*!
      * @brief Compute the start location of the halo for a given pair of neighbouring domains.
      *
-     * For example, in the diagram above. If we want to compute the start location for the halo of
+     * For example, in the diagram below. If we want to compute the start location for the halo of
      * domain 1 which is the LEFT neighbour of domain 2, halo_start should return 4 (see square
      * bracket in diagram below).
      *         memory             domains          halo required

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -57,9 +57,9 @@ public:
     void get_bounding_box(int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const;
 
     /*!
-     * @brief Returns vectors containing the MPI ranks and halo sizes of the neighbours of this
-     * process in the domain interior after partitioning. The neighbours are ordered left, right,
-     * bottom, top.
+     * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of the
+     * neighbours of this process in the domain interior after partitioning. The neighbours are
+     * ordered left, right, bottom, top.
      *
      * @param ids MPI ranks of the neighbours for each direction
      * @param halo_sizes Halo sizes of the neighbours for each direction
@@ -70,9 +70,9 @@ public:
         std::vector<std::vector<int>>& halo_starts) const;
 
     /*!
-     * @brief Returns vectors containing the MPI ranks and halo sizes of the periodic neighbours of
-     * this process in the domain interior after partitioning. The neighbours are ordered left,
-     * right, bottom, top.
+     * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of the
+     * neighbours of this process across periodic boundaries after partitioning. The neighbours are
+     * ordered left, right, bottom, top.
      *
      * @param ids MPI ranks of the periodic neighbours for each direction
      * @param halo_sizes Halo sizes of the periodic neighbours for each direction
@@ -173,17 +173,16 @@ protected:
 
     // Vector of maps of periodic neighbours to their halo sizes after partitioning
     std::vector<std::map<int, int>> _neighbours_p = std::vector<std::map<int, int>>(NNBRS);
-    //
+
     // Vector of maps of periodic neighbours to their halo start indices after partitioning
     std::vector<std::map<int, int>> _halo_starts_p = std::vector<std::map<int, int>>(NNBRS);
 
 private:
     /*!
-     * @brief Check if 2 domains are neighbouring. If true, then domain 2 is
-     * the [edge] neighbour of domain 1, relative to domain 1.
-     * e.g., if domain 2 is to the right of domain 1, the following call will
-     * return true
-     * is_neighbour(d1, d2, RIGHT) == true
+     * @brief Check if two domains are neighbouring. If true, then domain 2 is the [edge] neighbour
+     * of domain 1, relative to domain 1. e.g., if domain 2 is to the right of domain 1, the
+     * following call will return true:
+     * is_neighbour(d1, d2, RIGHT)
      *
      * @param d1 first domain
      * @param d2 second domain
@@ -196,8 +195,38 @@ private:
         const bool is_py = false);
 
     /*!
-     * @brief Compute the start location of the halo for a given pair of domains. This should only
-     * be called if the two domains have already been confirmed as neighbours using is_neighbour().
+     * @brief Compute the start location of the halo for a given pair of neighbouring domains.
+     *
+     * For example, in the diagram above. If we want to compute the start location for the halo of
+     * domain 1 which is the LEFT neighbour of domain 2, halo_start should return 4 (see square
+     * bracket in diagram below).
+     *         memory             domains          halo required
+     *   4┌───────────┬─────┐ ┌──────────┬────┐  ┌──────────┬────┐
+     *    │ 5 6 7 8 9 │ 6 7 │ │          │    │  │         9│    │
+     *    │           │     │ │    1     │    │  │          │    │
+     *    │ 0 1 2 3[4]│ 4 5 │ │          │    │  │         4│    │
+     *   2├───────────┤     │ ├──────────┤  2 │  ├──────────┤    │
+     *    │ 5 6 7 8 9 │ 2 3 │ │          │    │  │          │    │
+     *    │           │     │ │    0     │    │  │          │    │
+     * Y▲ │ 0 1 2 3 4 │ 0 1 │ │          │    │  │          │    │
+     *  │ └───────────┴─────┘ └──────────┴────┘  └──────────┴────┘
+     *  │0            5     7
+     *  └───►X
+     *
+     * Another example. If we want the start location of the halo for domain 0 which is domain 1's
+     * BOTTOM neighbour. We want halo_start to return 5. (see square bracket in diagram below).
+     *         memory             domains          halo required
+     *   4┌───────────┬─────┐ ┌──────────┬────┐  ┌──────────┬────┐
+     *    │ 5 6 7 8 9 │ 6 7 │ │          │    │  │          │    │
+     *    │           │     │ │    1     │    │  │          │    │
+     *    │ 0 1 2 3 4 │ 4 5 │ │          │    │  │          │    │
+     *   2├───────────┤     │ ├──────────┤  2 │  ├──────────┤    │
+     *    │[5]6 7 8 9 │ 2 3 │ │          │    │  │5 6 7 8 9 │    │
+     *    │           │     │ │    0     │    │  │          │    │
+     * Y▲ │ 0 1 2 3 4 │ 0 1 │ │          │    │  │          │    │
+     *  │ └───────────┴─────┘ └──────────┴────┘  └──────────┴────┘
+     *  │0            5     7
+     *  └───►X
      *
      * @param d1 first domain
      * @param d2 second domain

--- a/test/test_1/ref_partition_metadata_3.cdl
+++ b/test/test_1/ref_partition_metadata_3.cdl
@@ -34,27 +34,35 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -63,11 +71,15 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
+   left_neighbour_halo_starts = 3, 3 ;
+
    right_neighbours = 1, 1, 0 ;
 
    right_neighbour_ids = 2, 2 ;
 
    right_neighbour_halos = 2, 2 ;
+
+   right_neighbour_halo_starts = 0, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -75,11 +87,15 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
+   bottom_neighbour_halo_starts = 4 ;
+
    top_neighbours = 1, 0, 0 ;
 
    top_neighbour_ids = 1 ;
 
    top_neighbour_halos = 4 ;
+
+   top_neighbour_halo_starts = 0 ;
 
    left_neighbours_periodic = 0, 0, 0 ;
 

--- a/test/test_1_px/ref_partition_metadata_3.cdl
+++ b/test/test_1_px/ref_partition_metadata_3.cdl
@@ -34,27 +34,35 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -63,11 +71,15 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
+   left_neighbour_halo_starts = 3, 3 ;
+
    right_neighbours = 1, 1, 0 ;
 
    right_neighbour_ids = 2, 2 ;
 
    right_neighbour_halos = 2, 2 ;
+
+   right_neighbour_halo_starts = 0, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -75,11 +87,15 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
+   bottom_neighbour_halo_starts = 4 ;
+
    top_neighbours = 1, 0, 0 ;
 
    top_neighbour_ids = 1 ;
 
    top_neighbour_halos = 4 ;
+
+   top_neighbour_halo_starts = 0 ;
 
    left_neighbours_periodic = 1, 1, 0 ;
 
@@ -87,11 +103,15 @@ group: connectivity {
 
    left_neighbour_halos_periodic = 2, 2 ;
 
+   left_neighbour_halo_starts_periodic = 1, 5 ;
+
    right_neighbours_periodic = 0, 0, 2 ;
 
    right_neighbour_ids_periodic = 0, 1 ;
 
    right_neighbour_halos_periodic = 2, 2 ;
+
+   right_neighbour_halo_starts_periodic = 0, 0 ;
 
    bottom_neighbours_periodic = 0, 0, 0 ;
 

--- a/test/test_1_px_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_px_py/ref_partition_metadata_3.cdl
@@ -34,27 +34,35 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -63,11 +71,15 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
+   left_neighbour_halo_starts = 3, 3 ;
+
    right_neighbours = 1, 1, 0 ;
 
    right_neighbour_ids = 2, 2 ;
 
    right_neighbour_halos = 2, 2 ;
+
+   right_neighbour_halo_starts = 0, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -75,11 +87,15 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
+   bottom_neighbour_halo_starts = 4 ;
+
    top_neighbours = 1, 0, 0 ;
 
    top_neighbour_ids = 1 ;
 
    top_neighbour_halos = 4 ;
+
+   top_neighbour_halo_starts = 0 ;
 
    left_neighbours_periodic = 1, 1, 0 ;
 
@@ -87,11 +103,15 @@ group: connectivity {
 
    left_neighbour_halos_periodic = 2, 2 ;
 
+   left_neighbour_halo_starts_periodic = 1, 5 ;
+
    right_neighbours_periodic = 0, 0, 2 ;
 
    right_neighbour_ids_periodic = 0, 1 ;
 
    right_neighbour_halos_periodic = 2, 2 ;
+
+   right_neighbour_halo_starts_periodic = 0, 0 ;
 
    bottom_neighbours_periodic = 1, 0, 1 ;
 
@@ -99,10 +119,14 @@ group: connectivity {
 
    bottom_neighbour_halos_periodic = 4, 2 ;
 
+   bottom_neighbour_halo_starts_periodic = 4, 6 ;
+
    top_neighbours_periodic = 0, 1, 1 ;
 
    top_neighbour_ids_periodic = 0, 2 ;
 
    top_neighbour_halos_periodic = 4, 2 ;
+
+   top_neighbour_halo_starts_periodic = 0, 0 ;
   } // group connectivity
 }

--- a/test/test_1_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_py/ref_partition_metadata_3.cdl
@@ -34,27 +34,35 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -63,11 +71,15 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
+   left_neighbour_halo_starts = 3, 3 ;
+
    right_neighbours = 1, 1, 0 ;
 
    right_neighbour_ids = 2, 2 ;
 
    right_neighbour_halos = 2, 2 ;
+
+   right_neighbour_halo_starts = 0, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -75,11 +87,15 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
+   bottom_neighbour_halo_starts = 4 ;
+
    top_neighbours = 1, 0, 0 ;
 
    top_neighbour_ids = 1 ;
 
    top_neighbour_halos = 4 ;
+
+   top_neighbour_halo_starts = 0 ;
 
    left_neighbours_periodic = 0, 0, 0 ;
 
@@ -91,10 +107,14 @@ group: connectivity {
 
    bottom_neighbour_halos_periodic = 4, 2 ;
 
+   bottom_neighbour_halo_starts_periodic = 4, 6 ;
+
    top_neighbours_periodic = 0, 1, 1 ;
 
    top_neighbour_ids_periodic = 0, 2 ;
 
    top_neighbour_halos_periodic = 4, 2 ;
+
+   top_neighbour_halo_starts_periodic = 0, 0 ;
   } // group connectivity
 }

--- a/test/test_2/ref_partition_metadata_3.cdl
+++ b/test/test_2/ref_partition_metadata_3.cdl
@@ -34,27 +34,35 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 1, 1 ;
@@ -63,11 +71,15 @@ group: connectivity {
 
    left_neighbour_halos = 4, 4 ;
 
+   left_neighbour_halo_starts = 1, 1 ;
+
    right_neighbours = 1, 1, 0 ;
 
    right_neighbour_ids = 1, 2 ;
 
    right_neighbour_halos = 4, 4 ;
+
+   right_neighbour_halo_starts = 0, 0 ;
 
    bottom_neighbours = 0, 0, 0 ;
 


### PR DESCRIPTION
In order to send halo regions via MPI in the dynamics, we need to know the size of the domains and the starting indices of the halo regions.

This PR adds functionality we need to parallelize nextsimdg dynamics.

The following improvements have been made.
- minor tweaks to `DomainUtils` to add helper methods
  - `get_width`
  - `get_height`
- added `Edge` enums and array `edges` for more readable loops over neighbours
- reworked neighbour checking to be more consistent between periodic and non-periodic neighbours
- add functionality to compute the starting indices for the halo regions in neighbouring domains
- replaced loops over `NNBRS` to use the new `edges` enums
- minor fix - ensure that `std::cerr` messages are followed by `exit(EXIT_FAILURE)`.

### TODO
- [x] update integration tests to reflect additional outputs (`halo_starts`)