### PR TITLE
Add send and recv locations

### DIFF
--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -4,8 +4,8 @@
  * @date 05 Nov 2024
  */
 
-#include "Partitioner.hpp"
 #include "DomainUtils.hpp"
+#include "Partitioner.hpp"
 #include "Utils.hpp"
 #include "ZoltanPartitioner.hpp"
 
@@ -52,31 +52,64 @@ bool Partitioner::is_neighbour(
     }
 }
 
-int Partitioner::halo_start(const Domain d1, const Domain d2, const Edge edge)
+void Partitioner::haloBufferPositions(
+    const Domain d1, const Domain d2, const Edge edge, int& send_pos, int& recv_pos)
 {
-    int start = 0;
+    // send_pos is the index where we will read the halo data from processes sending their data
+    // recv_pos is the index where we will write the halo data into that rank's recv buffer
+
+    // Both indices (send_pos and recv_pos) are relative indices in the send and recv buffers used
+    // in NextSim. The dimension of each buffer may be different for each rank. Each rank will have
+    // it's own send and recv buffer. The size of each buffer will depend on each domain's
+    // perimeter. The send buffer for each rank is formed by taking the outer edges of the 2D domain
+    // and unrolling them into a 1D array in the order of Bottom, Right, Top and Left edges. The
+    // recv buffer is formed from the data gathered during the halo exchange. It is also laid out a
+    // similar way in memory.
+
+    send_pos = 0;
     if (edge == TOP) {
         // dx is the offset between domains
         int dx = std::max(d1.p1.x, d2.p1.x) - d2.p1.x;
-        // in this case the start location is equivalent
-        start = dx;
+        // in this case d1 is the TOP nieghbour of d2, which means it will need to share elements
+        // from it's BOTTOM edge, which is first in the 1D perimeter array. Therefore there is no
+        // additional offset
+        send_pos = dx;
     } else if (edge == BOTTOM) {
         // dx is the offset between domains
         int dx = std::max(d1.p1.x, d2.p1.x) - d2.p1.x;
-        // start will be in last row in the 2D-domain, therefore we need to account for (ny-1) * nx
-        // elements that come before the offset dx.
-        start = (d2.get_height() - 1) * d2.get_width() + dx;
+        // in this case d1 is the BOTTOM nieghbour of d2, which means it will need to share elements
+        // from it's TOP edge, which comes third in the 1D perimeter array (i.e., Bottom, Right and
+        // then Top). Therefore we have to account for an additional offset.
+        send_pos = d2.get_height() + d2.get_width() + dx;
     } else if (edge == LEFT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d2.p1.y;
-        start = ((dy + 1) * d2.get_width()) - 1;
+        send_pos = d2.get_width() + dy;
     } else if (edge == RIGHT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d2.p1.y;
-        start = dy * d2.get_width();
+        send_pos = 2 * d2.get_width() + d2.get_height() + dy;
     } else {
         std::cerr << "ERROR: edge must be LEFT, RIGHT, BOTTOM, TOP." << std::endl;
         exit(EXIT_FAILURE);
     }
-    return start;
+    // this logic here is similar to send_pos but it is a mirror reflection between L<->R and T<->B
+    // and 1<->2
+    recv_pos = 0;
+    if (edge == TOP) {
+        int dx = std::max(d1.p1.x, d2.p1.x) - d1.p1.x;
+        recv_pos = d1.get_height() + d1.get_width() + dx;
+    } else if (edge == BOTTOM) {
+        int dx = std::max(d1.p1.x, d2.p1.x) - d1.p1.x;
+        recv_pos = dx;
+    } else if (edge == LEFT) {
+        int dy = std::max(d1.p1.y, d2.p1.y) - d1.p1.y;
+        recv_pos = 2 * d1.get_width() + d1.get_height() + dy;
+    } else if (edge == RIGHT) {
+        int dy = std::max(d1.p1.y, d2.p1.y) - d1.p1.y;
+        recv_pos = d1.get_width() + dy;
+    } else {
+        std::cerr << "ERROR: edge must be LEFT, RIGHT, BOTTOM, TOP." << std::endl;
+        exit(EXIT_FAILURE);
+    }
 }
 
 Partitioner::Partitioner(MPI_Comm comm)
@@ -95,31 +128,33 @@ void Partitioner::get_bounding_box(
     local_ext_1 = _local_ext_new[1];
 }
 
-void Partitioner::get_neighbour_info(std::vector<std::vector<int>>& ids,
-    std::vector<std::vector<int>>& halo_sizes, std::vector<std::vector<int>>& halo_starts) const
+void Partitioner::get_neighbour_info(std::array<std::vector<int>, N_EDGE>& ids,
+    std::array<std::vector<int>, N_EDGE>& halo_sizes,
+    std::array<std::vector<int>, N_EDGE>& halo_send,
+    std::array<std::vector<int>, N_EDGE>& halo_recv) const
 {
     for (auto edge : edges) {
         for (auto it = _neighbours[edge].begin(); it != _neighbours[edge].end(); ++it) {
             ids[edge].push_back(it->first);
             halo_sizes[edge].push_back(it->second);
-        }
-        for (auto it = _halo_starts[edge].begin(); it != _halo_starts[edge].end(); ++it) {
-            halo_starts[edge].push_back(it->second);
+            halo_send[edge].push_back(_send_pos[edge].at(it->first));
+            halo_recv[edge].push_back(_recv_pos[edge].at(it->first));
         }
     }
 }
 
-void Partitioner::get_neighbour_info_periodic(std::vector<std::vector<int>>& ids,
-    std::vector<std::vector<int>>& halo_sizes, std::vector<std::vector<int>>& halo_starts) const
+void Partitioner::get_neighbour_info_periodic(std::array<std::vector<int>, N_EDGE>& ids,
+    std::array<std::vector<int>, N_EDGE>& halo_sizes,
+    std::array<std::vector<int>, N_EDGE>& halo_send,
+    std::array<std::vector<int>, N_EDGE>& halo_recv) const
 {
     for (auto edge : edges) {
         if (((edge == LEFT || edge == RIGHT) && _px) || ((edge == TOP || edge == BOTTOM) && _py)) {
             for (auto it = _neighbours_p[edge].begin(); it != _neighbours_p[edge].end(); ++it) {
                 ids[edge].push_back(it->first);
                 halo_sizes[edge].push_back(it->second);
-            }
-            for (auto it = _halo_starts_p[edge].begin(); it != _halo_starts_p[edge].end(); ++it) {
-                halo_starts[edge].push_back(it->second);
+                halo_send[edge].push_back(_send_pos_p[edge].at(it->first));
+                halo_recv[edge].push_back(_recv_pos_p[edge].at(it->first));
             }
         }
     }
@@ -184,8 +219,8 @@ void Partitioner::save_metadata(const std::string& filename) const
     }
 
     // Prepare neighbour data
-    std::vector<std::vector<int>> ids(N_EDGE), halos(N_EDGE), halo_starts(N_EDGE);
-    get_neighbour_info(ids, halos, halo_starts);
+    std::array<std::vector<int>, N_EDGE> ids, halos, halo_send, halo_recv;
+    get_neighbour_info(ids, halos, halo_send, halo_recv);
     std::vector<int> num_neighbours(N_EDGE), dims(N_EDGE, 0), offsets(N_EDGE, 0);
     for (auto edge : edges) {
         num_neighbours[edge] = (int)ids[edge].size();
@@ -194,8 +229,8 @@ void Partitioner::save_metadata(const std::string& filename) const
     }
 
     // Prepare periodic neighbour data
-    std::vector<std::vector<int>> ids_p(N_EDGE), halos_p(N_EDGE), halo_starts_p(N_EDGE);
-    get_neighbour_info_periodic(ids_p, halos_p, halo_starts_p);
+    std::array<std::vector<int>, N_EDGE> ids_p, halos_p, halo_send_p, halo_recv_p;
+    get_neighbour_info_periodic(ids_p, halos_p, halo_send_p, halo_recv_p);
     std::vector<int> num_neighbours_p(N_EDGE), dims_p(N_EDGE, 0), offsets_p(N_EDGE, 0);
     for (auto edge : edges) {
         num_neighbours_p[edge] = (int)ids_p[edge].size();
@@ -239,7 +274,8 @@ void Partitioner::save_metadata(const std::string& filename) const
 
     int ids_vid[N_EDGE];
     int halos_vid[N_EDGE];
-    int halo_starts_vid[N_EDGE];
+    int halo_send_vid[N_EDGE];
+    int halo_recv_vid[N_EDGE];
     for (auto edge : edges) {
         // Connectivity group
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbours").c_str(), NC_INT, 1,
@@ -248,14 +284,17 @@ void Partitioner::save_metadata(const std::string& filename) const
             1, &dimids[edge], &ids_vid[edge]));
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halos").c_str(),
             NC_INT, 1, &dimids[edge], &halos_vid[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_starts").c_str(),
-            NC_INT, 1, &dimids[edge], &halo_starts_vid[edge]));
+        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_send").c_str(),
+            NC_INT, 1, &dimids[edge], &halo_send_vid[edge]));
+        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_recv").c_str(),
+            NC_INT, 1, &dimids[edge], &halo_recv_vid[edge]));
     }
 
     int num_vid_p[N_EDGE];
     int ids_vid_p[N_EDGE];
     int halos_vid_p[N_EDGE];
-    int halo_starts_vid_p[N_EDGE];
+    int halo_send_vid_p[N_EDGE];
+    int halo_recv_vid_p[N_EDGE];
     for (auto edge : edges) {
         // Periodic members of connectivity group
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbours_periodic").c_str(),
@@ -266,8 +305,11 @@ void Partitioner::save_metadata(const std::string& filename) const
             nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halos_periodic").c_str(),
                 NC_INT, 1, &dimids_p[edge], &halos_vid_p[edge]));
         NC_CHECK(nc_def_var(connectivity_gid,
-            (dir_names[edge] + "_neighbour_halo_starts_periodic").c_str(), NC_INT, 1,
-            &dimids_p[edge], &halo_starts_vid_p[edge]));
+            (dir_names[edge] + "_neighbour_halo_send_periodic").c_str(), NC_INT, 1, &dimids_p[edge],
+            &halo_send_vid_p[edge]));
+        NC_CHECK(nc_def_var(connectivity_gid,
+            (dir_names[edge] + "_neighbour_halo_recv_periodic").c_str(), NC_INT, 1, &dimids_p[edge],
+            &halo_recv_vid_p[edge]));
     }
 
     // Write metadata to file
@@ -299,9 +341,11 @@ void Partitioner::save_metadata(const std::string& filename) const
         NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid[edge], NC_COLLECTIVE));
         NC_CHECK(
             nc_put_vara_int(connectivity_gid, halos_vid[edge], &start, &count, halos[edge].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, halo_starts_vid[edge], NC_COLLECTIVE));
+        NC_CHECK(nc_var_par_access(connectivity_gid, halo_send_vid[edge], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halo_starts_vid[edge], &start, &count, halo_starts[edge].data()));
+            connectivity_gid, halo_send_vid[edge], &start, &count, halo_send[edge].data()));
+        NC_CHECK(nc_put_vara_int(
+            connectivity_gid, halo_recv_vid[edge], &start, &count, halo_recv[edge].data()));
         // IDs and halos for periodic dimensions
         start = offsets_p[edge];
         count = num_neighbours_p[edge];
@@ -312,7 +356,9 @@ void Partitioner::save_metadata(const std::string& filename) const
         NC_CHECK(nc_put_vara_int(
             connectivity_gid, halos_vid_p[edge], &start, &count, halos_p[edge].data()));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halo_starts_vid_p[edge], &start, &count, halo_starts_p[edge].data()));
+            connectivity_gid, halo_send_vid_p[edge], &start, &count, halo_send_p[edge].data()));
+        NC_CHECK(nc_put_vara_int(
+            connectivity_gid, halo_recv_vid_p[edge], &start, &count, halo_recv_p[edge].data()));
     }
     NC_CHECK(nc_close(nc_id));
 }
@@ -412,8 +458,11 @@ void Partitioner::discover_neighbours()
                     int halo_size = domain_overlap(domains[_rank], domains[p], edge);
                     if (halo_size > 0) {
                         _neighbours[edge].insert(std::pair<int, int>(p, halo_size));
-                        int start = halo_start(domains[_rank], domains[p], edge);
-                        _halo_starts[edge].insert(std::pair<int, int>(p, start));
+                        int sendPos = 0;
+                        int recvPos = 0;
+                        haloBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
+                        _send_pos[edge].insert(std::pair<int, int>(p, sendPos));
+                        _recv_pos[edge].insert(std::pair<int, int>(p, recvPos));
                     }
                 }
             }
@@ -426,8 +475,11 @@ void Partitioner::discover_neighbours()
                 int halo_size = domain_overlap(domains[_rank], domains[p], edge);
                 if (halo_size > 0) {
                     _neighbours_p[edge].insert(std::pair<int, int>(p, halo_size));
-                    int start = halo_start(domains[_rank], domains[p], edge);
-                    _halo_starts_p[edge].insert(std::pair<int, int>(p, start));
+                    int sendPos = 0;
+                    int recvPos = 0;
+                    haloBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
+                    _send_pos_p[edge].insert(std::pair<int, int>(p, sendPos));
+                    _recv_pos_p[edge].insert(std::pair<int, int>(p, recvPos));
                 }
             }
         }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -4,8 +4,8 @@
  * @date 05 Nov 2024
  */
 
-#include "DomainUtils.hpp"
 #include "Partitioner.hpp"
+#include "DomainUtils.hpp"
 #include "Utils.hpp"
 #include "ZoltanPartitioner.hpp"
 

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -63,11 +63,13 @@ public:
      *
      * @param ids MPI ranks of the neighbours for each direction
      * @param halo_sizes Halo sizes of the neighbours for each direction
-     * @param halo_starts Halo starting indices of the neighbours for each direction
+     * @param halo_send index in send buffer to get halo data
+     * @param halo_recv index in recv buffer to put halo data
      */
-    void get_neighbour_info(std::vector<std::vector<int>>& ids,
-        std::vector<std::vector<int>>& halo_sizes,
-        std::vector<std::vector<int>>& halo_starts) const;
+    void get_neighbour_info(std::array<std::vector<int>, N_EDGE>& ids,
+        std::array<std::vector<int>, N_EDGE>& halo_sizes,
+        std::array<std::vector<int>, N_EDGE>& halo_send,
+        std::array<std::vector<int>, N_EDGE>& halo_recv) const;
 
     /*!
      * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of the
@@ -76,11 +78,13 @@ public:
      *
      * @param ids MPI ranks of the periodic neighbours for each direction
      * @param halo_sizes Halo sizes of the periodic neighbours for each direction
-     * @param halo_starts Halo starting indices of the periodic neighbours for each direction
+     * @param halo_send index in send buffer to get halo data
+     * @param halo_recv index in recv buffer to put halo data
      */
-    void get_neighbour_info_periodic(std::vector<std::vector<int>>& ids,
-        std::vector<std::vector<int>>& halo_sizes,
-        std::vector<std::vector<int>>& halo_starts) const;
+    void get_neighbour_info_periodic(std::array<std::vector<int>, N_EDGE>& ids,
+        std::array<std::vector<int>, N_EDGE>& halo_sizes,
+        std::array<std::vector<int>, N_EDGE>& halo_send,
+        std::array<std::vector<int>, N_EDGE>& halo_recv) const;
 
     /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a
@@ -168,14 +172,24 @@ protected:
     // Vector of maps of neighbours to their halo sizes after partitioning
     std::vector<std::map<int, int>> _neighbours = std::vector<std::map<int, int>>(NNBRS);
 
-    // Vector of maps of neighbours to their halo start indices after partitioning
-    std::vector<std::map<int, int>> _halo_starts = std::vector<std::map<int, int>>(NNBRS);
+    // Vector of maps of neighbours to their send buffer indices - index of data to fetch from send
+    // buffer
+    std::vector<std::map<int, int>> _send_pos = std::vector<std::map<int, int>>(NNBRS);
+
+    // Vector of maps of neighbours to their recv (receive) buffer indices - index where data will
+    // be stored in the recv buffer
+    std::vector<std::map<int, int>> _recv_pos = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of periodic neighbours to their halo sizes after partitioning
     std::vector<std::map<int, int>> _neighbours_p = std::vector<std::map<int, int>>(NNBRS);
 
-    // Vector of maps of periodic neighbours to their halo start indices after partitioning
-    std::vector<std::map<int, int>> _halo_starts_p = std::vector<std::map<int, int>>(NNBRS);
+    // Vector of maps of periodic neighbours to their send buffer indices - index of data to fetch
+    // from send buffer
+    std::vector<std::map<int, int>> _send_pos_p = std::vector<std::map<int, int>>(NNBRS);
+
+    // Vector of maps of periodic neighbours to their recv (receive) buffer indices - index where
+    // data will be stored in the recv buffer
+    std::vector<std::map<int, int>> _recv_pos_p = std::vector<std::map<int, int>>(NNBRS);
 
 private:
     /*!
@@ -196,6 +210,8 @@ private:
 
     /*!
      * @brief Compute the start location of the halo for a given pair of neighbouring domains.
+     *
+     * TODO: This needs to be updated to reflect changes to halo start
      *
      * For example, in the diagram below. If we want to compute the start location for the halo of
      * domain 1 which is the LEFT neighbour of domain 2, halo_start should return 4 (see square
@@ -233,7 +249,8 @@ private:
      * @param edge LEFT, RIGHT, BOTTOM or TOP
      * @return starting index of halo for the flattened domain array
      */
-    int halo_start(const Domain d1, const Domain d2, const Edge edge);
+    void haloBufferPositions(
+        const Domain d1, const Domain d2, const Edge edge, int& sendPos, int& recvPos);
 
 public:
     struct LIB_EXPORT Factory {

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <iostream>
 
+#include "DomainUtils.hpp"
 #include "Grid.hpp"
 #include "Partitioner.hpp"
 
@@ -82,10 +83,8 @@ int main(int argc, char* argv[])
     partitioner->partition(*grid);
 
     // Retrieve neighbours
-    vector<vector<int>> ids = { {}, {}, {}, {} };
-    vector<vector<int>> halos = { {}, {}, {}, {} };
-    vector<vector<int>> haloStarts = { {}, {}, {}, {} };
-    partitioner->get_neighbour_info(ids, halos, haloStarts);
+    array<vector<int>, N_EDGE> ids, halos, halo_send, halo_recv;
+    partitioner->get_neighbour_info(ids, halos, halo_send, halo_recv);
 
     // MPI ranks of neighbours in order: top, bottom, left, right
     vector<int> ids_tblr(ids[3]);

--- a/test/test_1/ref_partition_metadata_3.cdl
+++ b/test/test_1/ref_partition_metadata_3.cdl
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
-   left_neighbour_halo_starts = 3, 3 ;
+   left_neighbour_halo_send = 4, 4 ;
+
+   left_neighbour_halo_recv = 8, 10 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 2, 2 ;
 
-   right_neighbour_halo_starts = 0, 4 ;
+   right_neighbour_halo_send = 8, 10 ;
+
+   right_neighbour_halo_recv = 4, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -87,7 +99,9 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
-   bottom_neighbour_halo_starts = 4 ;
+   bottom_neighbour_halo_send = 6 ;
+
+   bottom_neighbour_halo_recv = 0 ;
 
    top_neighbours = 1, 0, 0 ;
 
@@ -95,7 +109,9 @@ group: connectivity {
 
    top_neighbour_halos = 4 ;
 
-   top_neighbour_halo_starts = 0 ;
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 6 ;
 
    left_neighbours_periodic = 0, 0, 0 ;
 

--- a/test/test_1_px/ref_partition_metadata_3.cdl
+++ b/test/test_1_px/ref_partition_metadata_3.cdl
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
-   left_neighbour_halo_starts = 3, 3 ;
+   left_neighbour_halo_send = 4, 4 ;
+
+   left_neighbour_halo_recv = 8, 10 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 2, 2 ;
 
-   right_neighbour_halo_starts = 0, 4 ;
+   right_neighbour_halo_send = 8, 10 ;
+
+   right_neighbour_halo_recv = 4, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -87,7 +99,9 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
-   bottom_neighbour_halo_starts = 4 ;
+   bottom_neighbour_halo_send = 6 ;
+
+   bottom_neighbour_halo_recv = 0 ;
 
    top_neighbours = 1, 0, 0 ;
 
@@ -95,7 +109,9 @@ group: connectivity {
 
    top_neighbour_halos = 4 ;
 
-   top_neighbour_halo_starts = 0 ;
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 6 ;
 
    left_neighbours_periodic = 1, 1, 0 ;
 
@@ -103,7 +119,9 @@ group: connectivity {
 
    left_neighbour_halos_periodic = 2, 2 ;
 
-   left_neighbour_halo_starts_periodic = 1, 5 ;
+   left_neighbour_halo_send_periodic = 2, 4 ;
+
+   left_neighbour_halo_recv_periodic = 10, 10 ;
 
    right_neighbours_periodic = 0, 0, 2 ;
 
@@ -111,7 +129,9 @@ group: connectivity {
 
    right_neighbour_halos_periodic = 2, 2 ;
 
-   right_neighbour_halo_starts_periodic = 0, 0 ;
+   right_neighbour_halo_send_periodic = 10, 10 ;
+
+   right_neighbour_halo_recv_periodic = 2, 4 ;
 
    bottom_neighbours_periodic = 0, 0, 0 ;
 

--- a/test/test_1_px_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_px_py/ref_partition_metadata_3.cdl
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
-   left_neighbour_halo_starts = 3, 3 ;
+   left_neighbour_halo_send = 4, 4 ;
+
+   left_neighbour_halo_recv = 8, 10 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 2, 2 ;
 
-   right_neighbour_halo_starts = 0, 4 ;
+   right_neighbour_halo_send = 8, 10 ;
+
+   right_neighbour_halo_recv = 4, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -87,7 +99,9 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
-   bottom_neighbour_halo_starts = 4 ;
+   bottom_neighbour_halo_send = 6 ;
+
+   bottom_neighbour_halo_recv = 0 ;
 
    top_neighbours = 1, 0, 0 ;
 
@@ -95,7 +109,9 @@ group: connectivity {
 
    top_neighbour_halos = 4 ;
 
-   top_neighbour_halo_starts = 0 ;
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 6 ;
 
    left_neighbours_periodic = 1, 1, 0 ;
 
@@ -103,7 +119,9 @@ group: connectivity {
 
    left_neighbour_halos_periodic = 2, 2 ;
 
-   left_neighbour_halo_starts_periodic = 1, 5 ;
+   left_neighbour_halo_send_periodic = 2, 4 ;
+
+   left_neighbour_halo_recv_periodic = 10, 10 ;
 
    right_neighbours_periodic = 0, 0, 2 ;
 
@@ -111,7 +129,9 @@ group: connectivity {
 
    right_neighbour_halos_periodic = 2, 2 ;
 
-   right_neighbour_halo_starts_periodic = 0, 0 ;
+   right_neighbour_halo_send_periodic = 10, 10 ;
+
+   right_neighbour_halo_recv_periodic = 2, 4 ;
 
    bottom_neighbours_periodic = 1, 0, 1 ;
 
@@ -119,7 +139,9 @@ group: connectivity {
 
    bottom_neighbour_halos_periodic = 4, 2 ;
 
-   bottom_neighbour_halo_starts_periodic = 4, 6 ;
+   bottom_neighbour_halo_send_periodic = 6, 6 ;
+
+   bottom_neighbour_halo_recv_periodic = 0, 0 ;
 
    top_neighbours_periodic = 0, 1, 1 ;
 
@@ -127,6 +149,8 @@ group: connectivity {
 
    top_neighbour_halos_periodic = 4, 2 ;
 
-   top_neighbour_halo_starts_periodic = 0, 0 ;
+   top_neighbour_halo_send_periodic = 0, 0 ;
+
+   top_neighbour_halo_recv_periodic = 6, 6 ;
   } // group connectivity
 }

--- a/test/test_1_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_py/ref_partition_metadata_3.cdl
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 2, 2 ;
 
-   left_neighbour_halo_starts = 3, 3 ;
+   left_neighbour_halo_send = 4, 4 ;
+
+   left_neighbour_halo_recv = 8, 10 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 2, 2 ;
 
-   right_neighbour_halo_starts = 0, 4 ;
+   right_neighbour_halo_send = 8, 10 ;
+
+   right_neighbour_halo_recv = 4, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -87,7 +99,9 @@ group: connectivity {
 
    bottom_neighbour_halos = 4 ;
 
-   bottom_neighbour_halo_starts = 4 ;
+   bottom_neighbour_halo_send = 6 ;
+
+   bottom_neighbour_halo_recv = 0 ;
 
    top_neighbours = 1, 0, 0 ;
 
@@ -95,7 +109,9 @@ group: connectivity {
 
    top_neighbour_halos = 4 ;
 
-   top_neighbour_halo_starts = 0 ;
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 6 ;
 
    left_neighbours_periodic = 0, 0, 0 ;
 
@@ -107,7 +123,9 @@ group: connectivity {
 
    bottom_neighbour_halos_periodic = 4, 2 ;
 
-   bottom_neighbour_halo_starts_periodic = 4, 6 ;
+   bottom_neighbour_halo_send_periodic = 6, 6 ;
+
+   bottom_neighbour_halo_recv_periodic = 0, 0 ;
 
    top_neighbours_periodic = 0, 1, 1 ;
 
@@ -115,6 +133,8 @@ group: connectivity {
 
    top_neighbour_halos_periodic = 4, 2 ;
 
-   top_neighbour_halo_starts_periodic = 0, 0 ;
+   top_neighbour_halo_send_periodic = 0, 0 ;
+
+   top_neighbour_halo_recv_periodic = 6, 6 ;
   } // group connectivity
 }

--- a/test/test_2/ref_partition_metadata_3.cdl
+++ b/test/test_2/ref_partition_metadata_3.cdl
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 1, 1 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 4, 4 ;
 
-   left_neighbour_halo_starts = 1, 1 ;
+   left_neighbour_halo_send = 2, 2 ;
+
+   left_neighbour_halo_recv = 8, 8 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 4, 4 ;
 
-   right_neighbour_halo_starts = 0, 0 ;
+   right_neighbour_halo_send = 8, 8 ;
+
+   right_neighbour_halo_recv = 2, 2 ;
 
    bottom_neighbours = 0, 0, 0 ;
 


### PR DESCRIPTION
NextSim halo logic needs to know which data to `send` and where to receive (`recv`) it. This PR adds those indices to the metadata output file which `decomp` produces and NextSim reads in.

