### PR TITLE
Add output prefix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          brew install bash
           brew install boost
           brew unlink pkg-config
           brew install pkgconf

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -54,12 +54,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          brew install bash
-          brew install cmake
           brew install boost
-          brew unlink pkg-config@0.29.2
+          brew unlink pkg-config
           brew install pkgconf
           brew link --overwrite pkgconf
+          brew install cmake
           brew install hdf5-mpi
           brew install pnetcdf
           git clone https://github.com/trilinos/Trilinos.git

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The project installs a shared library that can be imported by other CMake projec
 
 Running the help of the `domain` tool gives the following:
 
-```
+```sh
 $ ./build/decomp -h
 Usage: ./build/decomp [options]
 Options:
@@ -118,7 +118,9 @@ Options:
                             or 'xy'
   -m [ --mask ] arg (=mask) Mask variable name in netCDF grid file
   -i [ --ignore-mask ]      Ignore mask in netCDF grid file
-
+  --periodic-x              Periodicity in x-direction
+  --periodic-y              Periodicity in y-direction
+  --output-prefix arg       Prefix for output filenames
 ```
 
 We can see that the most of the options have defaults (shown in parentheses) e.g., if you do not specify the name of the land

--- a/main.cpp
+++ b/main.cpp
@@ -53,7 +53,8 @@ int main(int argc, char* argv[])
         ("mask,m", po::value<string>()->default_value("mask"), "Mask variable name in netCDF grid file")
         ("ignore-mask,i", po::bool_switch()->default_value(false), "Ignore mask in netCDF grid file")
         ("periodic-x,px", po::bool_switch()->default_value(false), "Periodicity in x-direction")
-        ("periodic-y,py", po::bool_switch()->default_value(false), "Periodicity in y-direction");
+        ("periodic-y,py", po::bool_switch()->default_value(false), "Periodicity in y-direction")
+        ("output-prefix,op", po::value<string>()->default_value(""), "Prefix for output filenames");
     // clang-format on
 
     // Parse optional command line options
@@ -74,6 +75,13 @@ int main(int argc, char* argv[])
         return 1;
     }
     std::vector<int> order = dimOrderFromStr(vm["order"].as<string>());
+    string prefix = vm["output-prefix"].as<string>();
+    if (prefix.find('/') != std::string::npos) {
+        throw std::invalid_argument("prefix must not contain '/'");
+    }
+    if (!prefix.empty()) {
+        prefix += "_";
+    }
 
     // Build grid from netCDF file
     Grid* grid = Grid::create(comm, vm["grid"].as<string>(), vm["xdim"].as<string>(),
@@ -90,8 +98,8 @@ int main(int argc, char* argv[])
     // Store partitioning results in netCDF file
     int num_procs;
     MPI_Comm_size(comm, &num_procs);
-    partitioner->save_mask("partition_mask_" + to_string(num_procs) + ".nc");
-    partitioner->save_metadata("partition_metadata_" + to_string(num_procs) + ".nc");
+    partitioner->save_mask(prefix + "partition_mask_" + to_string(num_procs) + ".nc");
+    partitioner->save_metadata(prefix + "partition_metadata_" + to_string(num_procs) + ".nc");
 
     // Cleanup
     delete grid;


### PR DESCRIPTION
Closes #73.

This PR adds an optional output prefix for the `partition_mask` and `partition_metadata` files and updates the README accordingly.

Also fixes the Mac CI.