### PR TITLE
Cosmetic changes

### DIFF
--- a/DomainUtils.cpp
+++ b/DomainUtils.cpp
@@ -9,10 +9,10 @@
 #include <algorithm>
 #include <iostream>
 
-int Domain::get_width() const { return p2.x - p1.x; }
-int Domain::get_height() const { return p2.y - p1.y; }
+int Domain::getWidth() const { return p2.x - p1.x; }
+int Domain::getHeight() const { return p2.y - p1.y; }
 
-int domain_overlap(const Domain d1, const Domain d2, const Edge edge)
+int domainOverlap(const Domain d1, const Domain d2, const Edge edge)
 {
     int overlap = 0;
     if (edge == TOP || edge == BOTTOM) {

--- a/DomainUtils.hpp
+++ b/DomainUtils.hpp
@@ -13,8 +13,8 @@
 enum Edge { LEFT, RIGHT, BOTTOM, TOP, N_EDGE };
 static constexpr std::array<Edge, N_EDGE> edges = { LEFT, RIGHT, BOTTOM, TOP };
 
-enum Vertex { TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT, N_VERTEX };
-static constexpr std::array<Vertex, N_VERTEX> vertices
+enum Corner { TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT, N_CORNER };
+static constexpr std::array<Corner, N_CORNER> corners
     = { TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT };
 
 /*!

--- a/DomainUtils.hpp
+++ b/DomainUtils.hpp
@@ -42,11 +42,11 @@ struct Domain {
     /*!
      * @brief return width of domain
      */
-    int get_width() const;
+    int getWidth() const;
     /*!
      * @brief return height of domain
      */
-    int get_height() const;
+    int getHeight() const;
 };
 
 /*!
@@ -59,6 +59,6 @@ struct Domain {
  * @param d2 Second Domain
  * @param dir direction to find overlap ('x' or 'y')
  */
-int domain_overlap(const Domain d1, const Domain d2, const Edge edge);
+int domainOverlap(const Domain d1, const Domain d2, const Edge edge);
 
 #endif /* DOMAINUTILS_HPP */

--- a/Grid.cpp
+++ b/Grid.cpp
@@ -68,7 +68,7 @@ void Grid::ReadGridExtents(const std::string& filename)
         NC_CHECK(nc_inq_dimid(data_nc_id, _dim_names[_dim_order[i]].c_str(), &dim_ids[i]));
         // get the extent of each dimension
         NC_CHECK(nc_inq_dimlen(data_nc_id, dim_ids[i], &tmp[i]));
-        _global_ext[_dim_order[i]] = static_cast<int>(tmp[i]);
+        _globalExt[_dim_order[i]] = static_cast<int>(tmp[i]);
     }
 
     NC_CHECK(nc_close(nc_id));
@@ -120,7 +120,7 @@ void Grid::ReadGridMask(const std::string& filename, const std::string& mask_nam
             // Position of first element
             start[_dim_order[i]] = static_cast<size_t>(_global[i]);
             // Number of elements to read
-            count[_dim_order[i]] = static_cast<size_t>(_local_ext[i]);
+            count[_dim_order[i]] = static_cast<size_t>(_localExt[i]);
         }
 
         NC_CHECK(nc_get_vara_int(data_nc_id, mask_nc_id, start, count, _land_mask.data()));
@@ -143,30 +143,30 @@ Grid::Grid(MPI_Comm comm, const std::string& filename, const std::string& xdim_n
 
     Grid::ReadGridExtents(filename);
 
-    CHECK_MPI(MPI_Comm_size(comm, &_total_num_procs));
+    CHECK_MPI(MPI_Comm_size(comm, &_totalNumProcs));
 
     // Initially we partition assuming there is no land mask
     // Start from a naive 2D decomposition
-    _num_procs = find_factors(_total_num_procs);
+    _numProcs = find_factors(_totalNumProcs);
 
     // split into chunks
     for (size_t i = 0; i < NDIMS; i++) {
-        _local_ext[i] = ceil((float)_global_ext[i] / (_num_procs[i]));
+        _localExt[i] = ceil((float)_globalExt[i] / (_numProcs[i]));
     }
 
     // need to account for residuals
-    _global[0] = (_rank / _num_procs[1]) * _local_ext[0];
-    _global[1] = (_rank % _num_procs[1]) * _local_ext[1];
+    _global[0] = (_rank / _numProcs[1]) * _localExt[0];
+    _global[1] = (_rank % _numProcs[1]) * _localExt[1];
 
-    if ((_rank / _num_procs[1]) == _num_procs[0] - 1) {
-        _local_ext[0] = _global_ext[0] - (_rank / _num_procs[1]) * _local_ext[0];
+    if ((_rank / _numProcs[1]) == _numProcs[0] - 1) {
+        _localExt[0] = _globalExt[0] - (_rank / _numProcs[1]) * _localExt[0];
     }
-    if ((_rank % _num_procs[1]) == _num_procs[1] - 1) {
-        _local_ext[1] = _global_ext[1] - (_rank % _num_procs[1]) * _local_ext[1];
+    if ((_rank % _numProcs[1]) == _numProcs[1] - 1) {
+        _localExt[1] = _globalExt[1] - (_rank % _numProcs[1]) * _localExt[1];
     }
 
     // number of objects for this process
-    _num_objects = _local_ext[0] * _local_ext[1];
+    _num_objects = _localExt[0] * _localExt[1];
 
     if (!ignore_mask) {
 
@@ -178,9 +178,9 @@ Grid::Grid(MPI_Comm comm, const std::string& filename, const std::string& xdim_n
             // and land points a zero value
             if (_land_mask[i] > 0) {
                 // find index position in the global grid
-                int temp_i = i % _local_ext[0] + _global[0];
-                int temp_j = i / _local_ext[0] + _global[1];
-                _global_id.push_back(temp_j * _global_ext[0] + temp_i);
+                int temp_i = i % _localExt[0] + _global[0];
+                int temp_j = i / _localExt[0] + _global[1];
+                _global_id.push_back(temp_j * _globalExt[0] + temp_i);
                 // store local id for mapping
                 _local_id.push_back(i);
                 _num_nonzero_objects++;
@@ -189,9 +189,9 @@ Grid::Grid(MPI_Comm comm, const std::string& filename, const std::string& xdim_n
     } else {
         _num_nonzero_objects = _num_objects;
         for (int i = 0; i < _num_objects; i++) {
-            int temp_i = i % _local_ext[0];
-            int temp_j = i / _local_ext[0];
-            _global_id.push_back(temp_j * _global_ext[0] + _global[0] + temp_i);
+            int temp_i = i % _localExt[0];
+            int temp_j = i / _localExt[0];
+            _global_id.push_back(temp_j * _globalExt[0] + _global[0] + temp_i);
             _local_id.push_back(i);
         }
     }
@@ -205,11 +205,11 @@ bool Grid::get_px() const { return _px; }
 
 bool Grid::get_py() const { return _py; }
 
-std::vector<int> Grid::get_num_procs() const { return _num_procs; }
+std::vector<int> Grid::getNumProcs() const { return _numProcs; }
 
-std::vector<int> Grid::get_global_ext() const { return _global_ext; }
+std::vector<int> Grid::getGlobalExt() const { return _globalExt; }
 
-std::vector<int> Grid::get_local_ext() const { return _local_ext; }
+std::vector<int> Grid::getLocalExt() const { return _localExt; }
 
 std::vector<int> Grid::get_global() const { return _global; }
 
@@ -219,10 +219,10 @@ const int* Grid::get_sparse_to_dense() const { return _local_id.data(); }
 
 const int* Grid::get_nonzero_object_ids() const { return _global_id.data(); }
 
-void Grid::get_bounding_box(int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const
+void Grid::get_bounding_box(int& global0, int& global1, int& localExt0, int& localExt1) const
 {
-    global_0 = _global[0];
-    global_1 = _global[1];
-    local_ext_0 = _local_ext[0];
-    local_ext_1 = _local_ext[1];
+    global0 = _global[0];
+    global1 = _global[1];
+    localExt0 = _localExt[0];
+    localExt1 = _localExt[1];
 }

--- a/Grid.hpp
+++ b/Grid.hpp
@@ -104,14 +104,14 @@ public:
      *
      * @return vector containing number of processes in each dimension of the grid
      */
-    std::vector<int> get_num_procs() const;
+    std::vector<int> getNumProcs() const;
 
     /*!
      * @brief Returns the local extent
      *
      * @return vector containing local extent in each dimension of the grid
      */
-    std::vector<int> get_local_ext() const;
+    std::vector<int> getLocalExt() const;
 
     /*!
      * @brief Returns the global position of the domain in the grid (bottom left corner of domain)
@@ -125,7 +125,7 @@ public:
      *
      * @return vector containing global extent in each dimension of the grid
      */
-    std::vector<int> get_global_ext() const;
+    std::vector<int> getGlobalExt() const;
 
     /*!
      * @brief Returns the global land mask dimensioned (dim0, dim1), where dim0 is
@@ -169,12 +169,12 @@ public:
     /*!
      * @brief Returns the bounding box for this process.
      *
-     * @param global_0 Global coordinate in the 1st dimension of the upper left corner.
-     * @param global_1 Global coordinate in the 2nd dimension of the upper left corner.
-     * @param local_ext_0 Local extent in the 1st dimension of the grid.
-     * @param local_ext_1 Local extent in the 2nd dimension of the grid.
+     * @param global0 Global coordinate in the 1st dimension of the upper left corner.
+     * @param global1 Global coordinate in the 2nd dimension of the upper left corner.
+     * @param localExt0 Local extent in the 1st dimension of the grid.
+     * @param localExt1 Local extent in the 2nd dimension of the grid.
      */
-    void get_bounding_box(int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const;
+    void get_bounding_box(int& global0, int& global1, int& localExt0, int& localExt1) const;
 
 private:
     // Construct a ditributed grid from a NetCDF file describing the global domain
@@ -205,25 +205,25 @@ public:
 private:
     MPI_Comm _comm; // MPI communicator
     int _rank = -1; // Process rank
-    int _total_num_procs = -1; // Total number of processes in communicator
+    int _totalNumProcs = -1; // Total number of processes in communicator
 
     // Total number of processes in each dimension
-    std::vector<int> _num_procs = std::vector<int>(NDIMS, -1);
+    std::vector<int> _numProcs = std::vector<int>(NDIMS, -1);
 
     // Global extents in each dimension
-    std::vector<int> _global_ext = std::vector<int>(NDIMS, 0);
+    std::vector<int> _globalExt = std::vector<int>(NDIMS, 0);
 
     // Local extents in each dimension
-    std::vector<int> _local_ext = std::vector<int>(NDIMS, 0);
+    std::vector<int> _localExt = std::vector<int>(NDIMS, 0);
 
     // Global coordinates of upper left corner
     std::vector<int> _global = std::vector<int>(NDIMS, -1);
 
     // Local extents in each dimension (after partitioning)
-    std::vector<int> _local_ext_new = std::vector<int>(NDIMS, 0);
+    std::vector<int> _localExtNew = std::vector<int>(NDIMS, 0);
 
     // Global coordinates of upper left corner (after partitioning)
-    std::vector<int> _global_new = std::vector<int>(NDIMS, -1);
+    std::vector<int> _globalNew = std::vector<int>(NDIMS, -1);
 
     // dimension names
     const std::vector<std::string> _dim_names;

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -38,8 +38,8 @@
  */
 int mod(int a, int n) { return ((a % n) + n) % n; }
 
-bool Partitioner::is_neighbour(
-    const Domain d1, const Domain d2, const Edge edge, const bool is_px, const bool is_py)
+bool Partitioner::isNeighbour(
+    const Domain d1, const Domain d2, const Edge edge, const bool isPx, const bool isPy)
 {
     // For TOP & BOTTOM Edges check that the domains share a y-coordinate AND that the horizontal
     // overlap is non-zero
@@ -47,26 +47,26 @@ bool Partitioner::is_neighbour(
     // For LEFT & RIGHT Edges check that the domains share a x-coordinate AND that the vertical
     // overlap is non-zero
     if (edge == TOP) {
-        if (is_py) {
-            return d1.p2.y == d2.p1.y + _global_ext[1] && d2.p1.x < d1.p2.x && d2.p2.x > d1.p1.x;
+        if (isPy) {
+            return d1.p2.y == d2.p1.y + _globalExt[1] && d2.p1.x < d1.p2.x && d2.p2.x > d1.p1.x;
         } else {
             return d1.p2.y == d2.p1.y && d2.p1.x < d1.p2.x && d2.p2.x > d1.p1.x;
         }
     } else if (edge == BOTTOM) {
-        if (is_py) {
-            return d1.p1.y == d2.p2.y - _global_ext[1] && d2.p1.x < d1.p2.x && d2.p2.x > d1.p1.x;
+        if (isPy) {
+            return d1.p1.y == d2.p2.y - _globalExt[1] && d2.p1.x < d1.p2.x && d2.p2.x > d1.p1.x;
         } else {
             return d1.p1.y == d2.p2.y && d2.p1.x < d1.p2.x && d2.p2.x > d1.p1.x;
         }
     } else if (edge == LEFT) {
-        if (is_px) {
-            return d1.p1.x == d2.p2.x - _global_ext[0] && d2.p1.y < d1.p2.y && d2.p2.y > d1.p1.y;
+        if (isPx) {
+            return d1.p1.x == d2.p2.x - _globalExt[0] && d2.p1.y < d1.p2.y && d2.p2.y > d1.p1.y;
         } else {
             return d1.p1.x == d2.p2.x && d2.p1.y < d1.p2.y && d2.p2.y > d1.p1.y;
         }
     } else if (edge == RIGHT) {
-        if (is_px) {
-            return d1.p2.x == d2.p1.x + _global_ext[0] && d2.p1.y < d1.p2.y && d2.p2.y > d1.p1.y;
+        if (isPx) {
+            return d1.p2.x == d2.p1.x + _globalExt[0] && d2.p1.y < d1.p2.y && d2.p2.y > d1.p1.y;
         } else {
             return d1.p2.x == d2.p1.x && d2.p1.y < d1.p2.y && d2.p2.y > d1.p1.y;
         }
@@ -76,8 +76,8 @@ bool Partitioner::is_neighbour(
     }
 }
 
-bool Partitioner::is_corner_neighbour(
-    const Domain d1, const Domain d2, const Corner corner, const bool is_px, const bool is_py)
+bool Partitioner::isCornerNeighbour(
+    const Domain d1, const Domain d2, const Corner corner, const bool isPx, const bool isPy)
 {
     // create helper vars for domain 1
     auto left = d1.p1.x;
@@ -86,19 +86,19 @@ bool Partitioner::is_corner_neighbour(
     auto bottom = d1.p1.y;
 
     // adjust for periodic boundaries if domain lies on one of the outer boundaries
-    if (is_px) {
+    if (isPx) {
         if (left == 0) {
-            left = _global_ext[0];
+            left = _globalExt[0];
         }
-        if (right == _global_ext[0]) {
+        if (right == _globalExt[0]) {
             right = 0;
         }
     }
-    if (is_py) {
+    if (isPy) {
         if (bottom == 0) {
-            bottom = _global_ext[1];
+            bottom = _globalExt[1];
         }
-        if (top == _global_ext[1]) {
+        if (top == _globalExt[1]) {
             top = 0;
         }
     }
@@ -120,12 +120,12 @@ bool Partitioner::is_corner_neighbour(
 }
 
 void Partitioner::haloEdgeBufferPositions(
-    const Domain d1, const Domain d2, const Edge edge, int& send_pos, int& recv_pos)
+    const Domain d1, const Domain d2, const Edge edge, int& sendPos, int& recvPos)
 {
-    // send_pos is the index where we will read the halo data from processes sending their data
-    // recv_pos is the index where we will write the halo data into that rank's recv buffer
+    // sendPos is the index where we will read the halo data from processes sending their data
+    // recvPos is the index where we will write the halo data into that rank's recv buffer
 
-    // Both indices (send_pos and recv_pos) are relative indices in the send and recv buffers used
+    // Both indices (sendPos and recvPos) are relative indices in the send and recv buffers used
     // in NextSim. The dimension of each buffer may be different for each rank. Each rank will have
     // it's own send and recv buffer. The size of each buffer will depend on each domain's
     // perimeter. The send buffer for each rank is formed by taking the outer edges of the 2D domain
@@ -133,46 +133,46 @@ void Partitioner::haloEdgeBufferPositions(
     // recv buffer is formed from the data gathered during the halo exchange. It is also laid out a
     // similar way in memory.
 
-    send_pos = 0;
+    sendPos = 0;
     if (edge == TOP) {
         // dx is the offset between domains
         int dx = std::max(d1.p1.x, d2.p1.x) - d2.p1.x;
         // in this case d2 is the TOP nieghbour of d1, which means it will need to share elements
         // from it's BOTTOM edge, which is first in the 1D perimeter array. Therefore there is no
         // additional offset
-        send_pos = dx;
+        sendPos = dx;
     } else if (edge == BOTTOM) {
         // dx is the offset between domains
         int dx = std::max(d1.p1.x, d2.p1.x) - d2.p1.x;
         // in this case d2 is the BOTTOM nieghbour of d1, which means it will need to share elements
         // from it's TOP edge, which comes third in the 1D perimeter array (i.e., Bottom, Right and
         // then Top). Therefore we have to account for an additional offset.
-        send_pos = d2.get_height() + d2.get_width() + dx;
+        sendPos = d2.getHeight() + d2.getWidth() + dx;
     } else if (edge == LEFT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d2.p1.y;
-        send_pos = d2.get_width() + dy;
+        sendPos = d2.getWidth() + dy;
     } else if (edge == RIGHT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d2.p1.y;
-        send_pos = 2 * d2.get_width() + d2.get_height() + dy;
+        sendPos = 2 * d2.getWidth() + d2.getHeight() + dy;
     } else {
         std::cerr << "ERROR: edge must be LEFT, RIGHT, BOTTOM, TOP." << std::endl;
         exit(EXIT_FAILURE);
     }
-    // this logic here is similar to send_pos but it is a mirror reflection between L<->R and T<->B
+    // this logic here is similar to sendPos but it is a mirror reflection between L<->R and T<->B
     // and 1<->2
-    recv_pos = 0;
+    recvPos = 0;
     if (edge == TOP) {
         int dx = std::max(d1.p1.x, d2.p1.x) - d1.p1.x;
-        recv_pos = d1.get_height() + d1.get_width() + dx;
+        recvPos = d1.getHeight() + d1.getWidth() + dx;
     } else if (edge == BOTTOM) {
         int dx = std::max(d1.p1.x, d2.p1.x) - d1.p1.x;
-        recv_pos = dx;
+        recvPos = dx;
     } else if (edge == LEFT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d1.p1.y;
-        recv_pos = 2 * d1.get_width() + d1.get_height() + dy;
+        recvPos = 2 * d1.getWidth() + d1.getHeight() + dy;
     } else if (edge == RIGHT) {
         int dy = std::max(d1.p1.y, d2.p1.y) - d1.p1.y;
-        recv_pos = d1.get_width() + dy;
+        recvPos = d1.getWidth() + dy;
     } else {
         std::cerr << "ERROR: edge must be LEFT, RIGHT, BOTTOM, TOP." << std::endl;
         exit(EXIT_FAILURE);
@@ -180,13 +180,13 @@ void Partitioner::haloEdgeBufferPositions(
 }
 
 void Partitioner::haloCornerBufferPositions(
-    const Domain d1, const Domain d2, const Corner corner, int& send_pos)
+    const Domain d1, const Domain d2, const Corner corner, int& sendPos)
 {
-    int globalX = _global_ext[0];
-    int globalY = _global_ext[1];
+    int globalX = _globalExt[0];
+    int globalY = _globalExt[1];
     int xpos, ypos;
 
-    send_pos = 0;
+    sendPos = 0;
     if (corner == TOP_RIGHT) {
         // for a TOP_RIGHT corner the corner neighbour can either be along the other domains bottom
         // or left edge. We need to check so we know where to look in the send buffer.
@@ -195,42 +195,42 @@ void Partitioner::haloCornerBufferPositions(
         if (ypos >= d2.p1.y) {
             // this first case is true if the corner neighbour lies on the left edge
             int dy = ypos - d2.p1.y;
-            send_pos = 2 * d2.get_width() + d2.get_height() + dy;
+            sendPos = 2 * d2.getWidth() + d2.getHeight() + dy;
         } else {
             // this second case works if the corner neighbour lies on the bottom edge (or in the
             // corner of both e.g., the bottom left corner)
             int dx = xpos - d2.p1.x;
-            send_pos = dx;
+            sendPos = dx;
         }
     } else if (corner == TOP_LEFT) {
         xpos = mod(d1.p1.x - 1, globalX);
         ypos = mod(d1.p2.y, globalY);
         if (ypos >= d2.p1.y) {
             int dy = ypos - d2.p1.y;
-            send_pos = d2.get_width() + dy;
+            sendPos = d2.getWidth() + dy;
         } else {
             int dx = xpos - d2.p1.x;
-            send_pos = dx;
+            sendPos = dx;
         }
     } else if (corner == BOTTOM_LEFT) {
         xpos = mod(d1.p1.x - 1, globalX);
         ypos = mod(d1.p1.y - 1, globalY);
         if (d2.p2.y >= ypos) {
             int dy = ypos - d2.p1.y;
-            send_pos = d2.get_width() + dy;
+            sendPos = d2.getWidth() + dy;
         } else {
             int dx = xpos - d2.p1.x;
-            send_pos = d2.get_width() + d2.get_height() + dx;
+            sendPos = d2.getWidth() + d2.getHeight() + dx;
         }
     } else if (corner == BOTTOM_RIGHT) {
         xpos = mod(d1.p2.x, globalX);
         ypos = mod(d1.p1.y - 1, globalY);
         if (d2.p2.y >= ypos) {
             int dy = ypos - d2.p1.y;
-            send_pos = 2 * d2.get_width() + d2.get_height() + dy;
+            sendPos = 2 * d2.getWidth() + d2.getHeight() + dy;
         } else {
             int dx = xpos - d2.p1.x;
-            send_pos = d2.get_width() + d2.get_height() + dx;
+            sendPos = d2.getWidth() + d2.getHeight() + dx;
         }
     } else {
         std::cerr << "ERROR: corner must be TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT."
@@ -242,79 +242,76 @@ void Partitioner::haloCornerBufferPositions(
 Partitioner::Partitioner(MPI_Comm comm)
 {
     _comm = comm;
-    CHECK_MPI(MPI_Comm_size(comm, &_total_num_procs));
+    CHECK_MPI(MPI_Comm_size(comm, &_totalNumProcs));
     CHECK_MPI(MPI_Comm_rank(comm, &_rank));
 }
 
-void Partitioner::get_bounding_box(
-    int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const
+void Partitioner::getBoundingBox(int& global0, int& global1, int& localExt0, int& localExt1) const
 {
-    global_0 = _global_new[0];
-    global_1 = _global_new[1];
-    local_ext_0 = _local_ext_new[0];
-    local_ext_1 = _local_ext_new[1];
+    global0 = _globalNew[0];
+    global1 = _globalNew[1];
+    localExt0 = _localExtNew[0];
+    localExt1 = _localExtNew[1];
 }
 
-void Partitioner::get_neighbour_info(std::array<std::vector<int>, N_EDGE>& ids,
-    std::array<std::vector<int>, N_EDGE>& halo_sizes,
-    std::array<std::vector<int>, N_EDGE>& halo_send,
-    std::array<std::vector<int>, N_EDGE>& halo_recv,
-    std::array<std::vector<int>, N_CORNER>& corner_ids,
-    std::array<std::vector<int>, N_CORNER>& corner_send) const
+void Partitioner::getNeighbourInfo(std::array<std::vector<int>, N_EDGE>& ids,
+    std::array<std::vector<int>, N_EDGE>& haloSizes, std::array<std::vector<int>, N_EDGE>& haloSend,
+    std::array<std::vector<int>, N_EDGE>& haloRecv,
+    std::array<std::vector<int>, N_CORNER>& cornerIds,
+    std::array<std::vector<int>, N_CORNER>& cornerSend) const
 {
     for (auto edge : edges) {
         for (auto it = _neighbours[edge].begin(); it != _neighbours[edge].end(); ++it) {
             ids[edge].push_back(it->first);
-            halo_sizes[edge].push_back(it->second);
-            halo_send[edge].push_back(_send_pos[edge].at(it->first));
-            halo_recv[edge].push_back(_recv_pos[edge].at(it->first));
+            haloSizes[edge].push_back(it->second);
+            haloSend[edge].push_back(_sendPos[edge].at(it->first));
+            haloRecv[edge].push_back(_recvPos[edge].at(it->first));
         }
     }
 
     for (auto corner : corners) {
-        for (auto it = _corner_neighbours[corner].begin(); it != _corner_neighbours[corner].end();
+        for (auto it = _cornerNeighbours[corner].begin(); it != _cornerNeighbours[corner].end();
              ++it) {
-            corner_ids[corner].push_back(it->first);
-            corner_send[corner].push_back(_corner_send_pos[corner].at(it->first));
+            cornerIds[corner].push_back(it->first);
+            cornerSend[corner].push_back(_cornerSendPos[corner].at(it->first));
         }
     }
 }
 
-void Partitioner::get_neighbour_info_periodic(std::array<std::vector<int>, N_EDGE>& ids,
-    std::array<std::vector<int>, N_EDGE>& halo_sizes,
-    std::array<std::vector<int>, N_EDGE>& halo_send,
-    std::array<std::vector<int>, N_EDGE>& halo_recv,
-    std::array<std::vector<int>, N_CORNER>& corner_ids,
-    std::array<std::vector<int>, N_CORNER>& corner_send) const
+void Partitioner::getNeighbourInfoPeriodic(std::array<std::vector<int>, N_EDGE>& ids,
+    std::array<std::vector<int>, N_EDGE>& haloSizes, std::array<std::vector<int>, N_EDGE>& haloSend,
+    std::array<std::vector<int>, N_EDGE>& haloRecv,
+    std::array<std::vector<int>, N_CORNER>& cornerIds,
+    std::array<std::vector<int>, N_CORNER>& cornerSend) const
 {
     for (auto edge : edges) {
         if (((edge == LEFT || edge == RIGHT) && _px) || ((edge == TOP || edge == BOTTOM) && _py)) {
 
             for (auto it = _neighbours_p[edge].begin(); it != _neighbours_p[edge].end(); ++it) {
                 ids[edge].push_back(it->first);
-                halo_sizes[edge].push_back(it->second);
-                halo_send[edge].push_back(_send_pos_p[edge].at(it->first));
-                halo_recv[edge].push_back(_recv_pos_p[edge].at(it->first));
+                haloSizes[edge].push_back(it->second);
+                haloSend[edge].push_back(_sendPos_p[edge].at(it->first));
+                haloRecv[edge].push_back(_recvPos_p[edge].at(it->first));
             }
         }
     }
 
     for (auto corner : corners) {
-        for (auto it = _corner_neighbours_p[corner].begin();
-             it != _corner_neighbours_p[corner].end(); ++it) {
-            corner_ids[corner].push_back(it->first);
-            corner_send[corner].push_back(_corner_send_pos_p[corner].at(it->first));
+        for (auto it = _cornerNeighbours_p[corner].begin(); it != _cornerNeighbours_p[corner].end();
+             ++it) {
+            cornerIds[corner].push_back(it->first);
+            cornerSend[corner].push_back(_cornerSendPos_p[corner].at(it->first));
         }
     }
 }
 
-void Partitioner::save_mask(const std::string& filename) const
+void Partitioner::saveMask(const std::string& filename) const
 {
     // Use C API for parallel I/O
     int nc_id, nc_mode;
     nc_mode = NC_CLOBBER | NC_NETCDF4;
     NC_CHECK(nc_create_par(filename.c_str(), nc_mode, _comm, MPI_INFO_NULL, &nc_id));
-    NC_CHECK(nc_put_att_int(nc_id, NC_GLOBAL, "num_processes", NC_INT, 1, &_total_num_procs));
+    NC_CHECK(nc_put_att_int(nc_id, NC_GLOBAL, "num_processes", NC_INT, 1, &_totalNumProcs));
 
     // Create 2 dimensions
     // The values to be written are associated with the netCDF variable by
@@ -325,7 +322,7 @@ void Partitioner::save_mask(const std::string& filename) const
     std::vector<std::string> dim_chars = { "y", "x" };
     for (int idx = 0; idx < NDIMS; idx++) {
         NC_CHECK(
-            nc_def_dim(nc_id, dim_chars[idx].c_str(), _global_ext[NDIMS - 1 - idx], &dimid[idx]));
+            nc_def_dim(nc_id, dim_chars[idx].c_str(), _globalExt[NDIMS - 1 - idx], &dimid[idx]));
     }
 
     // Create variables
@@ -339,16 +336,16 @@ void Partitioner::save_mask(const std::string& filename) const
     size_t start[NDIMS], count[NDIMS];
     for (int idx = 0; idx < NDIMS; idx++) {
         start[idx] = _global[NDIMS - 1 - idx];
-        count[idx] = _local_ext[NDIMS - 1 - idx];
+        count[idx] = _localExt[NDIMS - 1 - idx];
     }
 
     // Store data
     NC_CHECK(nc_var_par_access(nc_id, mask_nc_id, NC_COLLECTIVE));
-    NC_CHECK(nc_put_vara_int(nc_id, mask_nc_id, start, count, _proc_id.data()));
+    NC_CHECK(nc_put_vara_int(nc_id, mask_nc_id, start, count, _procId.data()));
     NC_CHECK(nc_close(nc_id));
 }
 
-void Partitioner::save_metadata(const std::string& filename) const
+void Partitioner::saveMetadata(const std::string& filename) const
 {
     // Use C API for parallel I/O
     int nc_id, nc_mode;
@@ -362,14 +359,14 @@ void Partitioner::save_metadata(const std::string& filename) const
     const int NDIMS = 2; // TODO: Why redeclared?
     int dimid_global[NDIMS];
     for (int idx = 0; idx < NDIMS; idx++) {
-        NC_CHECK(nc_def_dim(
-            nc_id, global_extent_names[idx].c_str(), _global_ext[idx], &dimid_global[idx]));
+        NC_CHECK(
+            nc_def_dim(nc_id, globalExtentNames[idx].c_str(), _globalExt[idx], &dimid_global[idx]));
     }
 
     // Prepare neighbour data
-    std::array<std::vector<int>, N_EDGE> ids, halos, halo_send, halo_recv;
-    std::array<std::vector<int>, N_CORNER> corner_ids, corner_send;
-    get_neighbour_info(ids, halos, halo_send, halo_recv, corner_ids, corner_send);
+    std::array<std::vector<int>, N_EDGE> ids, halos, haloSend, haloRecv;
+    std::array<std::vector<int>, N_CORNER> corner_ids, cornerSend;
+    getNeighbourInfo(ids, halos, haloSend, haloRecv, corner_ids, cornerSend);
 
     std::vector<int> num_neighbours(N_EDGE), dims(N_EDGE, 0), offsets(N_EDGE, 0);
     for (auto edge : edges) {
@@ -378,21 +375,20 @@ void Partitioner::save_metadata(const std::string& filename) const
         CHECK_MPI(MPI_Exscan(&num_neighbours[edge], &offsets[edge], 1, MPI_INT, MPI_SUM, _comm));
     }
 
-    std::vector<int> num_corner_neighbours(N_CORNER), corner_dims(N_CORNER, 0),
+    std::vector<int> numCornerNeighbours(N_CORNER), corner_dims(N_CORNER, 0),
         corner_offsets(N_CORNER, 0);
     for (auto corner : corners) {
-        num_corner_neighbours[corner] = (int)corner_ids[corner].size();
+        numCornerNeighbours[corner] = (int)corner_ids[corner].size();
         CHECK_MPI(MPI_Allreduce(
-            &num_corner_neighbours[corner], &corner_dims[corner], 1, MPI_INT, MPI_SUM, _comm));
+            &numCornerNeighbours[corner], &corner_dims[corner], 1, MPI_INT, MPI_SUM, _comm));
         CHECK_MPI(MPI_Exscan(
-            &num_corner_neighbours[corner], &corner_offsets[corner], 1, MPI_INT, MPI_SUM, _comm));
+            &numCornerNeighbours[corner], &corner_offsets[corner], 1, MPI_INT, MPI_SUM, _comm));
     }
 
     // Prepare periodic neighbour data
-    std::array<std::vector<int>, N_EDGE> ids_p, halos_p, halo_send_p, halo_recv_p;
-    std::array<std::vector<int>, N_CORNER> corner_ids_p, corner_send_p;
-    get_neighbour_info_periodic(
-        ids_p, halos_p, halo_send_p, halo_recv_p, corner_ids_p, corner_send_p);
+    std::array<std::vector<int>, N_EDGE> ids_p, halos_p, haloSend_p, haloRecv_p;
+    std::array<std::vector<int>, N_CORNER> corner_ids_p, cornerSend_p;
+    getNeighbourInfoPeriodic(ids_p, halos_p, haloSend_p, haloRecv_p, corner_ids_p, cornerSend_p);
     std::vector<int> num_neighbours_p(N_EDGE), dims_p(N_EDGE, 0), offsets_p(N_EDGE, 0);
     for (auto edge : edges) {
         num_neighbours_p[edge] = (int)ids_p[edge].size();
@@ -402,20 +398,20 @@ void Partitioner::save_metadata(const std::string& filename) const
             MPI_Exscan(&num_neighbours_p[edge], &offsets_p[edge], 1, MPI_INT, MPI_SUM, _comm));
     }
 
-    std::vector<int> num_corner_neighbours_p(N_CORNER), corner_dims_p(N_CORNER, 0),
+    std::vector<int> numCornerNeighbours_p(N_CORNER), corner_dims_p(N_CORNER, 0),
         corner_offsets_p(N_CORNER, 0);
     for (auto corner : corners) {
-        num_corner_neighbours_p[corner] = (int)corner_ids_p[corner].size();
+        numCornerNeighbours_p[corner] = (int)corner_ids_p[corner].size();
         CHECK_MPI(MPI_Allreduce(
-            &num_corner_neighbours_p[corner], &corner_dims_p[corner], 1, MPI_INT, MPI_SUM, _comm));
-        CHECK_MPI(MPI_Exscan(&num_corner_neighbours_p[corner], &corner_offsets_p[corner], 1,
-            MPI_INT, MPI_SUM, _comm));
+            &numCornerNeighbours_p[corner], &corner_dims_p[corner], 1, MPI_INT, MPI_SUM, _comm));
+        CHECK_MPI(MPI_Exscan(
+            &numCornerNeighbours_p[corner], &corner_offsets_p[corner], 1, MPI_INT, MPI_SUM, _comm));
     }
 
     // Define dimensions in netCDF file
     int dimid;
     std::vector<int> dimids(N_EDGE);
-    NC_CHECK(nc_def_dim(nc_id, "P", _total_num_procs, &dimid));
+    NC_CHECK(nc_def_dim(nc_id, "P", _totalNumProcs, &dimid));
     for (auto edge : edges) {
         NC_CHECK(nc_def_dim(nc_id, dir_chars[edge].c_str(), dims[edge], &dimids[edge]));
     }
@@ -458,8 +454,8 @@ void Partitioner::save_metadata(const std::string& filename) const
 
     int ids_vid[N_EDGE];
     int halos_vid[N_EDGE];
-    int halo_send_vid[N_EDGE];
-    int halo_recv_vid[N_EDGE];
+    int haloSend_vid[N_EDGE];
+    int haloRecv_vid[N_EDGE];
     for (auto edge : edges) {
         // Connectivity group
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbours").c_str(), NC_INT, 1,
@@ -469,14 +465,14 @@ void Partitioner::save_metadata(const std::string& filename) const
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halos").c_str(),
             NC_INT, 1, &dimids[edge], &halos_vid[edge]));
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_send").c_str(),
-            NC_INT, 1, &dimids[edge], &halo_send_vid[edge]));
+            NC_INT, 1, &dimids[edge], &haloSend_vid[edge]));
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_recv").c_str(),
-            NC_INT, 1, &dimids[edge], &halo_recv_vid[edge]));
+            NC_INT, 1, &dimids[edge], &haloRecv_vid[edge]));
     }
 
     int num_corner_vid[N_CORNER];
     int ids_corner_vid[N_CORNER];
-    int corner_send_vid[N_CORNER];
+    int cornerSend_vid[N_CORNER];
     for (auto corner : corners) {
         // Connectivity group
         NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbours").c_str(),
@@ -485,14 +481,14 @@ void Partitioner::save_metadata(const std::string& filename) const
             NC_INT, 1, &corner_dimids[corner], &ids_corner_vid[corner]));
         NC_CHECK(
             nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbour_send").c_str(),
-                NC_INT, 1, &corner_dimids[corner], &corner_send_vid[corner]));
+                NC_INT, 1, &corner_dimids[corner], &cornerSend_vid[corner]));
     }
 
     int num_vid_p[N_EDGE];
     int ids_vid_p[N_EDGE];
     int halos_vid_p[N_EDGE];
-    int halo_send_vid_p[N_EDGE];
-    int halo_recv_vid_p[N_EDGE];
+    int haloSend_vid_p[N_EDGE];
+    int haloRecv_vid_p[N_EDGE];
     for (auto edge : edges) {
         // Periodic members of connectivity group
         NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbours_periodic").c_str(),
@@ -504,15 +500,15 @@ void Partitioner::save_metadata(const std::string& filename) const
                 NC_INT, 1, &dimids_p[edge], &halos_vid_p[edge]));
         NC_CHECK(nc_def_var(connectivity_gid,
             (dir_names[edge] + "_neighbour_halo_send_periodic").c_str(), NC_INT, 1, &dimids_p[edge],
-            &halo_send_vid_p[edge]));
+            &haloSend_vid_p[edge]));
         NC_CHECK(nc_def_var(connectivity_gid,
             (dir_names[edge] + "_neighbour_halo_recv_periodic").c_str(), NC_INT, 1, &dimids_p[edge],
-            &halo_recv_vid_p[edge]));
+            &haloRecv_vid_p[edge]));
     }
 
     int num_corner_vid_p[N_CORNER];
     int ids_corner_vid_p[N_CORNER];
-    int corner_send_vid_p[N_CORNER];
+    int cornerSend_vid_p[N_CORNER];
     for (auto corner : corners) {
         // Connectivity group
         NC_CHECK(nc_def_var(connectivity_gid,
@@ -523,7 +519,7 @@ void Partitioner::save_metadata(const std::string& filename) const
             &corner_dimids_p[corner], &ids_corner_vid_p[corner]));
         NC_CHECK(nc_def_var(connectivity_gid,
             (corner_dir_names[corner] + "_neighbour_send_periodic").c_str(), NC_INT, 1,
-            &corner_dimids_p[corner], &corner_send_vid_p[corner]));
+            &corner_dimids_p[corner], &cornerSend_vid_p[corner]));
     }
 
     // Write metadata to file
@@ -533,9 +529,9 @@ void Partitioner::save_metadata(const std::string& filename) const
     for (int idx = 0; idx < NDIMS; idx++) {
         size_t start = _rank;
         NC_CHECK(nc_var_par_access(bbox_gid, top_vid[idx], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(bbox_gid, top_vid[idx], &start, &_global_new[idx]));
+        NC_CHECK(nc_put_var1_int(bbox_gid, top_vid[idx], &start, &_globalNew[idx]));
         NC_CHECK(nc_var_par_access(bbox_gid, cnt_vid[idx], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(bbox_gid, cnt_vid[idx], &start, &_local_ext_new[idx]));
+        NC_CHECK(nc_put_var1_int(bbox_gid, cnt_vid[idx], &start, &_localExtNew[idx]));
     }
     for (auto edge : edges) {
         // Numbers of neighbours
@@ -555,11 +551,11 @@ void Partitioner::save_metadata(const std::string& filename) const
         NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid[edge], NC_COLLECTIVE));
         NC_CHECK(
             nc_put_vara_int(connectivity_gid, halos_vid[edge], &start, &count, halos[edge].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, halo_send_vid[edge], NC_COLLECTIVE));
+        NC_CHECK(nc_var_par_access(connectivity_gid, haloSend_vid[edge], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halo_send_vid[edge], &start, &count, halo_send[edge].data()));
+            connectivity_gid, haloSend_vid[edge], &start, &count, haloSend[edge].data()));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halo_recv_vid[edge], &start, &count, halo_recv[edge].data()));
+            connectivity_gid, haloRecv_vid[edge], &start, &count, haloRecv[edge].data()));
         // IDs and halos for periodic dimensions
         start = offsets_p[edge];
         count = num_neighbours_p[edge];
@@ -570,9 +566,9 @@ void Partitioner::save_metadata(const std::string& filename) const
         NC_CHECK(nc_put_vara_int(
             connectivity_gid, halos_vid_p[edge], &start, &count, halos_p[edge].data()));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halo_send_vid_p[edge], &start, &count, halo_send_p[edge].data()));
+            connectivity_gid, haloSend_vid_p[edge], &start, &count, haloSend_p[edge].data()));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halo_recv_vid_p[edge], &start, &count, halo_recv_p[edge].data()));
+            connectivity_gid, haloRecv_vid_p[edge], &start, &count, haloRecv_p[edge].data()));
     }
 
     for (auto corner : corners) {
@@ -580,31 +576,31 @@ void Partitioner::save_metadata(const std::string& filename) const
         size_t start = _rank;
         NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(
-            connectivity_gid, num_corner_vid[corner], &start, &num_corner_neighbours[corner]));
+            connectivity_gid, num_corner_vid[corner], &start, &numCornerNeighbours[corner]));
         // Numbers of corner neighbours for periodic dimensions
         NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid_p[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(
-            connectivity_gid, num_corner_vid_p[corner], &start, &num_corner_neighbours_p[corner]));
+            connectivity_gid, num_corner_vid_p[corner], &start, &numCornerNeighbours_p[corner]));
 
         // "Corner" IDs and halos
         start = corner_offsets[corner];
-        size_t count = num_corner_neighbours[corner];
+        size_t count = numCornerNeighbours[corner];
         NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
             connectivity_gid, ids_corner_vid[corner], &start, &count, corner_ids[corner].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, corner_send_vid[corner], NC_COLLECTIVE));
+        NC_CHECK(nc_var_par_access(connectivity_gid, cornerSend_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, corner_send_vid[corner], &start, &count, corner_send[corner].data()));
+            connectivity_gid, cornerSend_vid[corner], &start, &count, cornerSend[corner].data()));
 
         // "Corner" IDs and halos for periodic dimensions
         start = corner_offsets_p[corner];
-        count = num_corner_neighbours_p[corner];
+        count = numCornerNeighbours_p[corner];
         NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid_p[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(connectivity_gid, ids_corner_vid_p[corner], &start, &count,
             corner_ids_p[corner].data()));
         NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid_p[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(connectivity_gid, corner_send_vid_p[corner], &start, &count,
-            corner_send_p[corner].data()));
+        NC_CHECK(nc_put_vara_int(connectivity_gid, cornerSend_vid_p[corner], &start, &count,
+            cornerSend_p[corner].data()));
     }
 
     NC_CHECK(nc_close(nc_id));
@@ -662,39 +658,39 @@ void Partitioner::discover_neighbours()
      */
 
     // Gather bounding boxes for all processes
-    std::vector<Point> origins(_total_num_procs);
-    std::vector<Point> extents(_total_num_procs);
-    std::vector<Domain> domains(_total_num_procs);
-    std::vector<int> tmp0(_total_num_procs);
-    std::vector<int> tmp1(_total_num_procs);
+    std::vector<Point> origins(_totalNumProcs);
+    std::vector<Point> extents(_totalNumProcs);
+    std::vector<Domain> domains(_totalNumProcs);
+    std::vector<int> tmp0(_totalNumProcs);
+    std::vector<int> tmp1(_totalNumProcs);
 
-    CHECK_MPI(MPI_Allgather(&_global_new[0], 1, MPI_INT, tmp0.data(), 1, MPI_INT, _comm));
-    CHECK_MPI(MPI_Allgather(&_global_new[1], 1, MPI_INT, tmp1.data(), 1, MPI_INT, _comm));
+    CHECK_MPI(MPI_Allgather(&_globalNew[0], 1, MPI_INT, tmp0.data(), 1, MPI_INT, _comm));
+    CHECK_MPI(MPI_Allgather(&_globalNew[1], 1, MPI_INT, tmp1.data(), 1, MPI_INT, _comm));
 
     // origin points mark the bottom-left corner of each domain
-    for (int p = 0; p < _total_num_procs; p++) {
+    for (int p = 0; p < _totalNumProcs; p++) {
         origins[p].x = tmp0[p];
         origins[p].y = tmp1[p];
     }
 
-    CHECK_MPI(MPI_Allgather(&_local_ext_new[0], 1, MPI_INT, tmp0.data(), 1, MPI_INT, _comm));
-    CHECK_MPI(MPI_Allgather(&_local_ext_new[1], 1, MPI_INT, tmp1.data(), 1, MPI_INT, _comm));
+    CHECK_MPI(MPI_Allgather(&_localExtNew[0], 1, MPI_INT, tmp0.data(), 1, MPI_INT, _comm));
+    CHECK_MPI(MPI_Allgather(&_localExtNew[1], 1, MPI_INT, tmp1.data(), 1, MPI_INT, _comm));
 
     // extents can be used to find the top-right corner of each domain
-    for (int p = 0; p < _total_num_procs; p++) {
+    for (int p = 0; p < _totalNumProcs; p++) {
         extents[p].x = tmp0[p];
         extents[p].y = tmp1[p];
     }
 
     // generate domains
-    for (int p = 0; p < _total_num_procs; p++) {
+    for (int p = 0; p < _totalNumProcs; p++) {
         domains[p].p1.x = origins[p].x;
         domains[p].p1.y = origins[p].y;
         domains[p].p2.x = origins[p].x + extents[p].x;
         domains[p].p2.y = origins[p].y + extents[p].y;
     }
 
-    for (int p = 0; p < _total_num_procs; p++) {
+    for (int p = 0; p < _totalNumProcs; p++) {
 
         // When finding neighbours *within* the domain, we don't check against the current rank
         // because a subdomain can't be a neighbour of itself.
@@ -702,26 +698,26 @@ void Partitioner::discover_neighbours()
 
             // check edge neighours
             for (auto edge : edges) {
-                if (is_neighbour(domains[_rank], domains[p], edge)) {
-                    int halo_size = domain_overlap(domains[_rank], domains[p], edge);
-                    if (halo_size > 0) {
-                        _neighbours[edge].insert(std::pair<int, int>(p, halo_size));
+                if (isNeighbour(domains[_rank], domains[p], edge)) {
+                    int haloSize = domainOverlap(domains[_rank], domains[p], edge);
+                    if (haloSize > 0) {
+                        _neighbours[edge].insert(std::pair<int, int>(p, haloSize));
                         int sendPos = 0;
                         int recvPos = 0;
                         haloEdgeBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
-                        _send_pos[edge].insert(std::pair<int, int>(p, sendPos));
-                        _recv_pos[edge].insert(std::pair<int, int>(p, recvPos));
+                        _sendPos[edge].insert(std::pair<int, int>(p, sendPos));
+                        _recvPos[edge].insert(std::pair<int, int>(p, recvPos));
                     }
                 }
             }
 
             // check corner neighours
             for (auto corner : corners) {
-                if (is_corner_neighbour(domains[_rank], domains[p], corner)) {
-                    _corner_neighbours[corner].insert(std::pair<int, int>(p, 1));
+                if (isCornerNeighbour(domains[_rank], domains[p], corner)) {
+                    _cornerNeighbours[corner].insert(std::pair<int, int>(p, 1));
                     int sendPos = 0;
                     haloCornerBufferPositions(domains[_rank], domains[p], corner, sendPos);
-                    _corner_send_pos[corner].insert(std::pair<int, int>(p, sendPos));
+                    _cornerSendPos[corner].insert(std::pair<int, int>(p, sendPos));
                 }
             }
         }
@@ -730,30 +726,30 @@ void Partitioner::discover_neighbours()
         // current rank, too, because a subdomain can be a periodic neighbour of itself.
         // check periodic edge neighours
         for (auto edge : edges) {
-            if (is_neighbour(domains[_rank], domains[p], edge, _px, _py)) {
-                int halo_size = domain_overlap(domains[_rank], domains[p], edge);
-                if (halo_size > 0) {
-                    _neighbours_p[edge].insert(std::pair<int, int>(p, halo_size));
+            if (isNeighbour(domains[_rank], domains[p], edge, _px, _py)) {
+                int haloSize = domainOverlap(domains[_rank], domains[p], edge);
+                if (haloSize > 0) {
+                    _neighbours_p[edge].insert(std::pair<int, int>(p, haloSize));
                     int sendPos = 0;
                     int recvPos = 0;
                     haloEdgeBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
-                    _send_pos_p[edge].insert(std::pair<int, int>(p, sendPos));
-                    _recv_pos_p[edge].insert(std::pair<int, int>(p, recvPos));
+                    _sendPos_p[edge].insert(std::pair<int, int>(p, sendPos));
+                    _recvPos_p[edge].insert(std::pair<int, int>(p, recvPos));
                 }
             }
         }
 
         // check periodic corner neighours
         for (auto corner : corners) {
-            if (is_corner_neighbour(domains[_rank], domains[p], corner, _px, _py)) {
-                if (_corner_neighbours[corner].size() > 0) {
+            if (isCornerNeighbour(domains[_rank], domains[p], corner, _px, _py)) {
+                if (_cornerNeighbours[corner].size() > 0) {
                     // skip if we have already counted as a non-periodic neighbour
                     continue;
                 }
-                _corner_neighbours_p[corner].insert(std::pair<int, int>(p, 1));
+                _cornerNeighbours_p[corner].insert(std::pair<int, int>(p, 1));
                 int sendPos = 0;
                 haloCornerBufferPositions(domains[_rank], domains[p], corner, sendPos);
-                _corner_send_pos_p[corner].insert(std::pair<int, int>(p, sendPos));
+                _cornerSendPos_p[corner].insert(std::pair<int, int>(p, sendPos));
             }
         }
     }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -119,7 +119,7 @@ bool Partitioner::is_corner_neighbour(
     }
 }
 
-void Partitioner::haloBufferPositions(
+void Partitioner::haloEdgeBufferPositions(
     const Domain d1, const Domain d2, const Edge edge, int& send_pos, int& recv_pos)
 {
     // send_pos is the index where we will read the halo data from processes sending their data
@@ -708,7 +708,7 @@ void Partitioner::discover_neighbours()
                         _neighbours[edge].insert(std::pair<int, int>(p, halo_size));
                         int sendPos = 0;
                         int recvPos = 0;
-                        haloBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
+                        haloEdgeBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
                         _send_pos[edge].insert(std::pair<int, int>(p, sendPos));
                         _recv_pos[edge].insert(std::pair<int, int>(p, recvPos));
                     }
@@ -736,7 +736,7 @@ void Partitioner::discover_neighbours()
                     _neighbours_p[edge].insert(std::pair<int, int>(p, halo_size));
                     int sendPos = 0;
                     int recvPos = 0;
-                    haloBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
+                    haloEdgeBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
                     _send_pos_p[edge].insert(std::pair<int, int>(p, sendPos));
                     _recv_pos_p[edge].insert(std::pair<int, int>(p, recvPos));
                 }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -77,7 +77,7 @@ bool Partitioner::is_neighbour(
 }
 
 bool Partitioner::is_corner_neighbour(
-    const Domain d1, const Domain d2, const Vertex vertex, const bool is_px, const bool is_py)
+    const Domain d1, const Domain d2, const Corner corner, const bool is_px, const bool is_py)
 {
     // create helper vars for domain 1
     auto left = d1.p1.x;
@@ -102,18 +102,18 @@ bool Partitioner::is_corner_neighbour(
             top = 0;
         }
     }
-    if (vertex == TOP_LEFT) {
+    if (corner == TOP_LEFT) {
         // Check if top and left coordinates of domain 1 fall in domain 2 (d2)
         // Similar logic applies to the other corners
         return top >= d2.p1.y && top < d2.p2.y && left > d2.p1.x && left <= d2.p2.x;
-    } else if (vertex == TOP_RIGHT) {
+    } else if (corner == TOP_RIGHT) {
         return top >= d2.p1.y && top < d2.p2.y && right < d2.p2.x && right >= d2.p1.x;
-    } else if (vertex == BOTTOM_RIGHT) {
+    } else if (corner == BOTTOM_RIGHT) {
         return bottom <= d2.p2.y && bottom > d2.p1.y && right >= d2.p1.x && right < d2.p2.x;
-    } else if (vertex == BOTTOM_LEFT) {
+    } else if (corner == BOTTOM_LEFT) {
         return bottom <= d2.p2.y && bottom > d2.p1.y && left <= d2.p2.x && left > d2.p1.x;
     } else {
-        std::cerr << "ERROR: vertex must be TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT."
+        std::cerr << "ERROR: corner must be TOP_LEFT, TOP_RIGHT, BOTTOM_RIGHT, BOTTOM_LEFT."
                   << std::endl;
         exit(EXIT_FAILURE);
     }
@@ -180,15 +180,15 @@ void Partitioner::haloEdgeBufferPositions(
 }
 
 void Partitioner::haloCornerBufferPositions(
-    const Domain d1, const Domain d2, const Vertex vertex, int& send_pos)
+    const Domain d1, const Domain d2, const Corner corner, int& send_pos)
 {
     int globalX = _global_ext[0];
     int globalY = _global_ext[1];
     int xpos, ypos;
 
     send_pos = 0;
-    if (vertex == TOP_RIGHT) {
-        // for a TOP_RIGHT vertex the corner neighbour can either be along the other domains bottom
+    if (corner == TOP_RIGHT) {
+        // for a TOP_RIGHT corner the corner neighbour can either be along the other domains bottom
         // or left edge. We need to check so we know where to look in the send buffer.
         xpos = mod(d1.p2.x, globalX);
         ypos = mod(d1.p2.y, globalY);
@@ -202,7 +202,7 @@ void Partitioner::haloCornerBufferPositions(
             int dx = xpos - d2.p1.x;
             send_pos = dx;
         }
-    } else if (vertex == TOP_LEFT) {
+    } else if (corner == TOP_LEFT) {
         xpos = mod(d1.p1.x - 1, globalX);
         ypos = mod(d1.p2.y, globalY);
         if (ypos >= d2.p1.y) {
@@ -212,7 +212,7 @@ void Partitioner::haloCornerBufferPositions(
             int dx = xpos - d2.p1.x;
             send_pos = dx;
         }
-    } else if (vertex == BOTTOM_LEFT) {
+    } else if (corner == BOTTOM_LEFT) {
         xpos = mod(d1.p1.x - 1, globalX);
         ypos = mod(d1.p1.y - 1, globalY);
         if (d2.p2.y >= ypos) {
@@ -222,7 +222,7 @@ void Partitioner::haloCornerBufferPositions(
             int dx = xpos - d2.p1.x;
             send_pos = d2.get_width() + d2.get_height() + dx;
         }
-    } else if (vertex == BOTTOM_RIGHT) {
+    } else if (corner == BOTTOM_RIGHT) {
         xpos = mod(d1.p2.x, globalX);
         ypos = mod(d1.p1.y - 1, globalY);
         if (d2.p2.y >= ypos) {
@@ -233,7 +233,7 @@ void Partitioner::haloCornerBufferPositions(
             send_pos = d2.get_width() + d2.get_height() + dx;
         }
     } else {
-        std::cerr << "ERROR: vertex must be TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT."
+        std::cerr << "ERROR: corner must be TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT."
                   << std::endl;
         exit(EXIT_FAILURE);
     }
@@ -259,8 +259,8 @@ void Partitioner::get_neighbour_info(std::array<std::vector<int>, N_EDGE>& ids,
     std::array<std::vector<int>, N_EDGE>& halo_sizes,
     std::array<std::vector<int>, N_EDGE>& halo_send,
     std::array<std::vector<int>, N_EDGE>& halo_recv,
-    std::array<std::vector<int>, N_VERTEX>& corner_ids,
-    std::array<std::vector<int>, N_VERTEX>& corner_send) const
+    std::array<std::vector<int>, N_CORNER>& corner_ids,
+    std::array<std::vector<int>, N_CORNER>& corner_send) const
 {
     for (auto edge : edges) {
         for (auto it = _neighbours[edge].begin(); it != _neighbours[edge].end(); ++it) {
@@ -271,11 +271,11 @@ void Partitioner::get_neighbour_info(std::array<std::vector<int>, N_EDGE>& ids,
         }
     }
 
-    for (auto vertex : vertices) {
-        for (auto it = _corner_neighbours[vertex].begin(); it != _corner_neighbours[vertex].end();
+    for (auto corner : corners) {
+        for (auto it = _corner_neighbours[corner].begin(); it != _corner_neighbours[corner].end();
              ++it) {
-            corner_ids[vertex].push_back(it->first);
-            corner_send[vertex].push_back(_corner_send_pos[vertex].at(it->first));
+            corner_ids[corner].push_back(it->first);
+            corner_send[corner].push_back(_corner_send_pos[corner].at(it->first));
         }
     }
 }
@@ -284,8 +284,8 @@ void Partitioner::get_neighbour_info_periodic(std::array<std::vector<int>, N_EDG
     std::array<std::vector<int>, N_EDGE>& halo_sizes,
     std::array<std::vector<int>, N_EDGE>& halo_send,
     std::array<std::vector<int>, N_EDGE>& halo_recv,
-    std::array<std::vector<int>, N_VERTEX>& corner_ids,
-    std::array<std::vector<int>, N_VERTEX>& corner_send) const
+    std::array<std::vector<int>, N_CORNER>& corner_ids,
+    std::array<std::vector<int>, N_CORNER>& corner_send) const
 {
     for (auto edge : edges) {
         if (((edge == LEFT || edge == RIGHT) && _px) || ((edge == TOP || edge == BOTTOM) && _py)) {
@@ -299,11 +299,11 @@ void Partitioner::get_neighbour_info_periodic(std::array<std::vector<int>, N_EDG
         }
     }
 
-    for (auto vertex : vertices) {
-        for (auto it = _corner_neighbours_p[vertex].begin();
-             it != _corner_neighbours_p[vertex].end(); ++it) {
-            corner_ids[vertex].push_back(it->first);
-            corner_send[vertex].push_back(_corner_send_pos_p[vertex].at(it->first));
+    for (auto corner : corners) {
+        for (auto it = _corner_neighbours_p[corner].begin();
+             it != _corner_neighbours_p[corner].end(); ++it) {
+            corner_ids[corner].push_back(it->first);
+            corner_send[corner].push_back(_corner_send_pos_p[corner].at(it->first));
         }
     }
 }
@@ -368,7 +368,7 @@ void Partitioner::save_metadata(const std::string& filename) const
 
     // Prepare neighbour data
     std::array<std::vector<int>, N_EDGE> ids, halos, halo_send, halo_recv;
-    std::array<std::vector<int>, N_VERTEX> corner_ids, corner_send;
+    std::array<std::vector<int>, N_CORNER> corner_ids, corner_send;
     get_neighbour_info(ids, halos, halo_send, halo_recv, corner_ids, corner_send);
 
     std::vector<int> num_neighbours(N_EDGE), dims(N_EDGE, 0), offsets(N_EDGE, 0);
@@ -378,19 +378,19 @@ void Partitioner::save_metadata(const std::string& filename) const
         CHECK_MPI(MPI_Exscan(&num_neighbours[edge], &offsets[edge], 1, MPI_INT, MPI_SUM, _comm));
     }
 
-    std::vector<int> num_corner_neighbours(N_VERTEX), corner_dims(N_VERTEX, 0),
-        corner_offsets(N_VERTEX, 0);
-    for (auto vertex : vertices) {
-        num_corner_neighbours[vertex] = (int)corner_ids[vertex].size();
+    std::vector<int> num_corner_neighbours(N_CORNER), corner_dims(N_CORNER, 0),
+        corner_offsets(N_CORNER, 0);
+    for (auto corner : corners) {
+        num_corner_neighbours[corner] = (int)corner_ids[corner].size();
         CHECK_MPI(MPI_Allreduce(
-            &num_corner_neighbours[vertex], &corner_dims[vertex], 1, MPI_INT, MPI_SUM, _comm));
+            &num_corner_neighbours[corner], &corner_dims[corner], 1, MPI_INT, MPI_SUM, _comm));
         CHECK_MPI(MPI_Exscan(
-            &num_corner_neighbours[vertex], &corner_offsets[vertex], 1, MPI_INT, MPI_SUM, _comm));
+            &num_corner_neighbours[corner], &corner_offsets[corner], 1, MPI_INT, MPI_SUM, _comm));
     }
 
     // Prepare periodic neighbour data
     std::array<std::vector<int>, N_EDGE> ids_p, halos_p, halo_send_p, halo_recv_p;
-    std::array<std::vector<int>, N_VERTEX> corner_ids_p, corner_send_p;
+    std::array<std::vector<int>, N_CORNER> corner_ids_p, corner_send_p;
     get_neighbour_info_periodic(
         ids_p, halos_p, halo_send_p, halo_recv_p, corner_ids_p, corner_send_p);
     std::vector<int> num_neighbours_p(N_EDGE), dims_p(N_EDGE, 0), offsets_p(N_EDGE, 0);
@@ -402,13 +402,13 @@ void Partitioner::save_metadata(const std::string& filename) const
             MPI_Exscan(&num_neighbours_p[edge], &offsets_p[edge], 1, MPI_INT, MPI_SUM, _comm));
     }
 
-    std::vector<int> num_corner_neighbours_p(N_VERTEX), corner_dims_p(N_VERTEX, 0),
-        corner_offsets_p(N_VERTEX, 0);
-    for (auto vertex : vertices) {
-        num_corner_neighbours_p[vertex] = (int)corner_ids_p[vertex].size();
+    std::vector<int> num_corner_neighbours_p(N_CORNER), corner_dims_p(N_CORNER, 0),
+        corner_offsets_p(N_CORNER, 0);
+    for (auto corner : corners) {
+        num_corner_neighbours_p[corner] = (int)corner_ids_p[corner].size();
         CHECK_MPI(MPI_Allreduce(
-            &num_corner_neighbours_p[vertex], &corner_dims_p[vertex], 1, MPI_INT, MPI_SUM, _comm));
-        CHECK_MPI(MPI_Exscan(&num_corner_neighbours_p[vertex], &corner_offsets_p[vertex], 1,
+            &num_corner_neighbours_p[corner], &corner_dims_p[corner], 1, MPI_INT, MPI_SUM, _comm));
+        CHECK_MPI(MPI_Exscan(&num_corner_neighbours_p[corner], &corner_offsets_p[corner], 1,
             MPI_INT, MPI_SUM, _comm));
     }
 
@@ -420,10 +420,10 @@ void Partitioner::save_metadata(const std::string& filename) const
         NC_CHECK(nc_def_dim(nc_id, dir_chars[edge].c_str(), dims[edge], &dimids[edge]));
     }
 
-    std::vector<int> corner_dimids(N_VERTEX);
-    for (auto vertex : vertices) {
+    std::vector<int> corner_dimids(N_CORNER);
+    for (auto corner : corners) {
         NC_CHECK(nc_def_dim(
-            nc_id, corner_dir_chars[vertex].c_str(), corner_dims[vertex], &corner_dimids[vertex]));
+            nc_id, corner_dir_chars[corner].c_str(), corner_dims[corner], &corner_dimids[corner]));
     }
 
     // Define periodic dimensions in netCDF file
@@ -433,7 +433,7 @@ void Partitioner::save_metadata(const std::string& filename) const
             nc_id, (dir_chars[edge] + "_periodic").c_str(), dims_p[edge], &dimids_p[edge]));
     }
 
-    std::vector<int> corner_dimids_p(N_VERTEX);
+    std::vector<int> corner_dimids_p(N_CORNER);
     for (auto edge : edges) {
         NC_CHECK(nc_def_dim(nc_id, (corner_dir_chars[edge] + "_periodic").c_str(),
             corner_dims_p[edge], &corner_dimids_p[edge]));
@@ -474,18 +474,18 @@ void Partitioner::save_metadata(const std::string& filename) const
             NC_INT, 1, &dimids[edge], &halo_recv_vid[edge]));
     }
 
-    int num_corner_vid[N_VERTEX];
-    int ids_corner_vid[N_VERTEX];
-    int corner_send_vid[N_VERTEX];
-    for (auto vertex : vertices) {
+    int num_corner_vid[N_CORNER];
+    int ids_corner_vid[N_CORNER];
+    int corner_send_vid[N_CORNER];
+    for (auto corner : corners) {
         // Connectivity group
-        NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[vertex] + "_neighbours").c_str(),
-            NC_INT, 1, &dimid, &num_corner_vid[vertex]));
-        NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[vertex] + "_neighbour_ids").c_str(),
-            NC_INT, 1, &corner_dimids[vertex], &ids_corner_vid[vertex]));
+        NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbours").c_str(),
+            NC_INT, 1, &dimid, &num_corner_vid[corner]));
+        NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbour_ids").c_str(),
+            NC_INT, 1, &corner_dimids[corner], &ids_corner_vid[corner]));
         NC_CHECK(
-            nc_def_var(connectivity_gid, (corner_dir_names[vertex] + "_neighbour_send").c_str(),
-                NC_INT, 1, &corner_dimids[vertex], &corner_send_vid[vertex]));
+            nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbour_send").c_str(),
+                NC_INT, 1, &corner_dimids[corner], &corner_send_vid[corner]));
     }
 
     int num_vid_p[N_EDGE];
@@ -510,20 +510,20 @@ void Partitioner::save_metadata(const std::string& filename) const
             &halo_recv_vid_p[edge]));
     }
 
-    int num_corner_vid_p[N_VERTEX];
-    int ids_corner_vid_p[N_VERTEX];
-    int corner_send_vid_p[N_VERTEX];
-    for (auto vertex : vertices) {
+    int num_corner_vid_p[N_CORNER];
+    int ids_corner_vid_p[N_CORNER];
+    int corner_send_vid_p[N_CORNER];
+    for (auto corner : corners) {
         // Connectivity group
         NC_CHECK(nc_def_var(connectivity_gid,
-            (corner_dir_names[vertex] + "_neighbours_periodic").c_str(), NC_INT, 1, &dimid,
-            &num_corner_vid_p[vertex]));
+            (corner_dir_names[corner] + "_neighbours_periodic").c_str(), NC_INT, 1, &dimid,
+            &num_corner_vid_p[corner]));
         NC_CHECK(nc_def_var(connectivity_gid,
-            (corner_dir_names[vertex] + "_neighbour_ids_periodic").c_str(), NC_INT, 1,
-            &corner_dimids_p[vertex], &ids_corner_vid_p[vertex]));
+            (corner_dir_names[corner] + "_neighbour_ids_periodic").c_str(), NC_INT, 1,
+            &corner_dimids_p[corner], &ids_corner_vid_p[corner]));
         NC_CHECK(nc_def_var(connectivity_gid,
-            (corner_dir_names[vertex] + "_neighbour_send_periodic").c_str(), NC_INT, 1,
-            &corner_dimids_p[vertex], &corner_send_vid_p[vertex]));
+            (corner_dir_names[corner] + "_neighbour_send_periodic").c_str(), NC_INT, 1,
+            &corner_dimids_p[corner], &corner_send_vid_p[corner]));
     }
 
     // Write metadata to file
@@ -575,36 +575,36 @@ void Partitioner::save_metadata(const std::string& filename) const
             connectivity_gid, halo_recv_vid_p[edge], &start, &count, halo_recv_p[edge].data()));
     }
 
-    for (auto vertex : vertices) {
+    for (auto corner : corners) {
         // Numbers of "corner" neighbours
         size_t start = _rank;
-        NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid[vertex], NC_COLLECTIVE));
+        NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(
-            connectivity_gid, num_corner_vid[vertex], &start, &num_corner_neighbours[vertex]));
+            connectivity_gid, num_corner_vid[corner], &start, &num_corner_neighbours[corner]));
         // Numbers of corner neighbours for periodic dimensions
-        NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid_p[vertex], NC_COLLECTIVE));
+        NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid_p[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(
-            connectivity_gid, num_corner_vid_p[vertex], &start, &num_corner_neighbours_p[vertex]));
+            connectivity_gid, num_corner_vid_p[corner], &start, &num_corner_neighbours_p[corner]));
 
         // "Corner" IDs and halos
-        start = corner_offsets[vertex];
-        size_t count = num_corner_neighbours[vertex];
-        NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid[vertex], NC_COLLECTIVE));
+        start = corner_offsets[corner];
+        size_t count = num_corner_neighbours[corner];
+        NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, ids_corner_vid[vertex], &start, &count, corner_ids[vertex].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, corner_send_vid[vertex], NC_COLLECTIVE));
+            connectivity_gid, ids_corner_vid[corner], &start, &count, corner_ids[corner].data()));
+        NC_CHECK(nc_var_par_access(connectivity_gid, corner_send_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
-            connectivity_gid, corner_send_vid[vertex], &start, &count, corner_send[vertex].data()));
+            connectivity_gid, corner_send_vid[corner], &start, &count, corner_send[corner].data()));
 
         // "Corner" IDs and halos for periodic dimensions
-        start = corner_offsets_p[vertex];
-        count = num_corner_neighbours_p[vertex];
-        NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid_p[vertex], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(connectivity_gid, ids_corner_vid_p[vertex], &start, &count,
-            corner_ids_p[vertex].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid_p[vertex], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(connectivity_gid, corner_send_vid_p[vertex], &start, &count,
-            corner_send_p[vertex].data()));
+        start = corner_offsets_p[corner];
+        count = num_corner_neighbours_p[corner];
+        NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid_p[corner], NC_COLLECTIVE));
+        NC_CHECK(nc_put_vara_int(connectivity_gid, ids_corner_vid_p[corner], &start, &count,
+            corner_ids_p[corner].data()));
+        NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid_p[corner], NC_COLLECTIVE));
+        NC_CHECK(nc_put_vara_int(connectivity_gid, corner_send_vid_p[corner], &start, &count,
+            corner_send_p[corner].data()));
     }
 
     NC_CHECK(nc_close(nc_id));
@@ -716,12 +716,12 @@ void Partitioner::discover_neighbours()
             }
 
             // check corner neighours
-            for (auto vertex : vertices) {
-                if (is_corner_neighbour(domains[_rank], domains[p], vertex)) {
-                    _corner_neighbours[vertex].insert(std::pair<int, int>(p, 1));
+            for (auto corner : corners) {
+                if (is_corner_neighbour(domains[_rank], domains[p], corner)) {
+                    _corner_neighbours[corner].insert(std::pair<int, int>(p, 1));
                     int sendPos = 0;
-                    haloCornerBufferPositions(domains[_rank], domains[p], vertex, sendPos);
-                    _corner_send_pos[vertex].insert(std::pair<int, int>(p, sendPos));
+                    haloCornerBufferPositions(domains[_rank], domains[p], corner, sendPos);
+                    _corner_send_pos[corner].insert(std::pair<int, int>(p, sendPos));
                 }
             }
         }
@@ -744,16 +744,16 @@ void Partitioner::discover_neighbours()
         }
 
         // check periodic corner neighours
-        for (auto vertex : vertices) {
-            if (is_corner_neighbour(domains[_rank], domains[p], vertex, _px, _py)) {
-                if (_corner_neighbours[vertex].size() > 0) {
+        for (auto corner : corners) {
+            if (is_corner_neighbour(domains[_rank], domains[p], corner, _px, _py)) {
+                if (_corner_neighbours[corner].size() > 0) {
                     // skip if we have already counted as a non-periodic neighbour
                     continue;
                 }
-                _corner_neighbours_p[vertex].insert(std::pair<int, int>(p, 1));
+                _corner_neighbours_p[corner].insert(std::pair<int, int>(p, 1));
                 int sendPos = 0;
-                haloCornerBufferPositions(domains[_rank], domains[p], vertex, sendPos);
-                _corner_send_pos_p[vertex].insert(std::pair<int, int>(p, sendPos));
+                haloCornerBufferPositions(domains[_rank], domains[p], corner, sendPos);
+                _corner_send_pos_p[corner].insert(std::pair<int, int>(p, sendPos));
             }
         }
     }

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -260,7 +260,7 @@ public:
      * @param sendPos position to get data from send buffer
      * @param recvPos position to store data in recv buffer
      */
-    void haloBufferPositions(
+    void haloEdgeBufferPositions(
         const Domain d1, const Domain d2, const Edge edge, int& sendPos, int& recvPos);
 
     /*!

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -72,8 +72,8 @@ public:
         std::array<std::vector<int>, N_EDGE>& halo_sizes,
         std::array<std::vector<int>, N_EDGE>& halo_send,
         std::array<std::vector<int>, N_EDGE>& halo_recv,
-        std::array<std::vector<int>, N_VERTEX>& corner_ids,
-        std::array<std::vector<int>, N_VERTEX>& corner_send) const;
+        std::array<std::vector<int>, N_CORNER>& corner_ids,
+        std::array<std::vector<int>, N_CORNER>& corner_send) const;
     /*!
      * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of
      * the neighbours of this process across periodic boundaries after partitioning. The
@@ -88,8 +88,8 @@ public:
         std::array<std::vector<int>, N_EDGE>& halo_sizes,
         std::array<std::vector<int>, N_EDGE>& halo_send,
         std::array<std::vector<int>, N_EDGE>& halo_recv,
-        std::array<std::vector<int>, N_VERTEX>& corner_ids,
-        std::array<std::vector<int>, N_VERTEX>& corner_send) const;
+        std::array<std::vector<int>, N_CORNER>& corner_ids,
+        std::array<std::vector<int>, N_CORNER>& corner_send) const;
 
     /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a
@@ -245,7 +245,7 @@ public:
      */
     bool is_neighbour(const Domain d1, const Domain d2, const Edge edge, const bool is_px = false,
         const bool is_py = false);
-    bool is_corner_neighbour(const Domain d1, const Domain d2, const Vertex vertex,
+    bool is_corner_neighbour(const Domain d1, const Domain d2, const Corner corner,
         const bool is_px = false, const bool is_py = false);
 
     /*!
@@ -272,5 +272,5 @@ public:
      * @param sendPos position to get data from send buffer
      */
     void haloCornerBufferPositions(
-        const Domain d1, const Domain d2, const Vertex vertex, int& sendPos);
+        const Domain d1, const Domain d2, const Corner corner, int& sendPos);
 };

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -48,14 +48,14 @@ public:
     /*!
      * @brief Returns the new bounding box for this process after partitioning.
      *
-     * @param global_0 Global coordinate in the 1st dimension of the upper left
+     * @param global0 Global coordinate in the 1st dimension of the upper left
      * corner.
-     * @param global_1 Global coordinate in the 2nd dimension of the upper left
+     * @param global1 Global coordinate in the 2nd dimension of the upper left
      * corner.
-     * @param local_ext_0 Local extent in the 1st dimension of the grid.
-     * @param local_ext_1 Local extent in the 2nd dimension of the grid.
+     * @param localExt0 Local extent in the 1st dimension of the grid.
+     * @param localExt1 Local extent in the 2nd dimension of the grid.
      */
-    void get_bounding_box(int& global_0, int& global_1, int& local_ext_0, int& local_ext_1) const;
+    void getBoundingBox(int& global0, int& global1, int& localExt0, int& localExt1) const;
 
     /*!
      * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of the
@@ -64,32 +64,32 @@ public:
      *
      * @param ids MPI ranks of the neighbours for each direction
      * @param corner_ids MPI ranks of the "corner" neighbours for each direction
-     * @param halo_sizes Halo sizes of the neighbours for each direction
-     * @param halo_send index in send buffer to get halo data
-     * @param halo_recv index in recv buffer to put halo data
+     * @param haloSizes Halo sizes of the neighbours for each direction
+     * @param haloSend index in send buffer to get halo data
+     * @param haloRecv index in recv buffer to put halo data
      */
-    void get_neighbour_info(std::array<std::vector<int>, N_EDGE>& ids,
-        std::array<std::vector<int>, N_EDGE>& halo_sizes,
-        std::array<std::vector<int>, N_EDGE>& halo_send,
-        std::array<std::vector<int>, N_EDGE>& halo_recv,
-        std::array<std::vector<int>, N_CORNER>& corner_ids,
-        std::array<std::vector<int>, N_CORNER>& corner_send) const;
+    void getNeighbourInfo(std::array<std::vector<int>, N_EDGE>& ids,
+        std::array<std::vector<int>, N_EDGE>& haloSizes,
+        std::array<std::vector<int>, N_EDGE>& haloSend,
+        std::array<std::vector<int>, N_EDGE>& haloRecv,
+        std::array<std::vector<int>, N_CORNER>& cornerIds,
+        std::array<std::vector<int>, N_CORNER>& cornerSend) const;
     /*!
      * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of
      * the neighbours of this process across periodic boundaries after partitioning. The
      * neighbours are ordered left, right, bottom, top.
      *
      * @param ids MPI ranks of the periodic neighbours for each direction
-     * @param halo_sizes Halo sizes of the periodic neighbours for each direction
-     * @param halo_send index in send buffer to get halo data
-     * @param halo_recv index in recv buffer to put halo data
+     * @param haloSizes Halo sizes of the periodic neighbours for each direction
+     * @param haloSend index in send buffer to get halo data
+     * @param haloRecv index in recv buffer to put halo data
      */
-    void get_neighbour_info_periodic(std::array<std::vector<int>, N_EDGE>& ids,
-        std::array<std::vector<int>, N_EDGE>& halo_sizes,
-        std::array<std::vector<int>, N_EDGE>& halo_send,
-        std::array<std::vector<int>, N_EDGE>& halo_recv,
-        std::array<std::vector<int>, N_CORNER>& corner_ids,
-        std::array<std::vector<int>, N_CORNER>& corner_send) const;
+    void getNeighbourInfoPeriodic(std::array<std::vector<int>, N_EDGE>& ids,
+        std::array<std::vector<int>, N_EDGE>& haloSizes,
+        std::array<std::vector<int>, N_EDGE>& haloSend,
+        std::array<std::vector<int>, N_EDGE>& haloRecv,
+        std::array<std::vector<int>, N_CORNER>& cornerIds,
+        std::array<std::vector<int>, N_CORNER>& cornerSend) const;
 
     /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a
@@ -101,7 +101,7 @@ public:
      *
      * @param filename Name of the NetCDF file.
      */
-    void save_mask(const std::string& filename) const;
+    void saveMask(const std::string& filename) const;
 
     /*!
      * @brief Saves the boxes and connectivity information of the latest domain
@@ -121,7 +121,7 @@ public:
      *
      * @param filename Name of the NetCDF file.
      */
-    void save_metadata(const std::string& filename) const;
+    void saveMetadata(const std::string& filename) const;
 
 protected:
     // Construct a partitioner
@@ -135,7 +135,7 @@ protected:
 protected:
     MPI_Comm _comm; // MPI communicator
     int _rank = -1; // Process rank
-    int _total_num_procs = -1; // Total number of processes in communicator
+    int _totalNumProcs = -1; // Total number of processes in communicator
     static const int NDIMS = 2; // Number of dimensions
     static const int NNBRS = 2 * NDIMS; // Number of neighbours (two per dimension)
     bool _px = false; // Periodic boundary in the x-direction
@@ -158,63 +158,63 @@ protected:
         = { "top_left", "top_right", "bottom_right", "bottom_left" };
 
     // Names used for global dimension extents
-    std::vector<std::string> global_extent_names = { "NX", "NY" };
+    std::vector<std::string> globalExtentNames = { "NX", "NY" };
 
     // Total number of processes in each dimension
-    std::vector<int> _num_procs = std::vector<int>(NDIMS, -1);
+    std::vector<int> _numProcs = std::vector<int>(NDIMS, -1);
 
     // Global extents in each dimension
-    std::vector<int> _global_ext = std::vector<int>(NDIMS, 0);
+    std::vector<int> _globalExt = std::vector<int>(NDIMS, 0);
 
     // Local extents in each dimension
-    std::vector<int> _local_ext = std::vector<int>(NDIMS, 0);
+    std::vector<int> _localExt = std::vector<int>(NDIMS, 0);
 
     // Global coordinates of upper left corner
     std::vector<int> _global = std::vector<int>(NDIMS, -1);
 
     // Local extents in each dimension (after partitioning)
-    std::vector<int> _local_ext_new = std::vector<int>(NDIMS, 0);
+    std::vector<int> _localExtNew = std::vector<int>(NDIMS, 0);
 
     // Global coordinates of upper left corner (after partitioning)
-    std::vector<int> _global_new = std::vector<int>(NDIMS, -1);
+    std::vector<int> _globalNew = std::vector<int>(NDIMS, -1);
 
     // Process ids of partition (dense form)
-    std::vector<int> _proc_id = {};
+    std::vector<int> _procId = {};
 
     // Vector of maps of neighbours to their halo sizes after partitioning
     std::vector<std::map<int, int>> _neighbours = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of "corner" neighbours to their halo sizes after partitioning (corners are all
     // of size 1)
-    std::vector<std::map<int, int>> _corner_neighbours = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _cornerNeighbours = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of neighbours to their send buffer indices - index of data to fetch from send
     // buffer
-    std::vector<std::map<int, int>> _send_pos = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _sendPos = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of neighbours to their recv (receive) buffer indices - index where data will
     // be stored in the recv buffer
-    std::vector<std::map<int, int>> _recv_pos = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _recvPos = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of "corner" neighbours to their halo start indices after partitioning
-    std::vector<std::map<int, int>> _corner_send_pos = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _cornerSendPos = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of periodic neighbours to their halo sizes after partitioning
     std::vector<std::map<int, int>> _neighbours_p = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of periodic neighbours to their send buffer indices - index of data to fetch
     // from send buffer
-    std::vector<std::map<int, int>> _send_pos_p = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _sendPos_p = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of periodic neighbours to their recv (receive) buffer indices - index where
     // data will be stored in the recv buffer
-    std::vector<std::map<int, int>> _recv_pos_p = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _recvPos_p = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of "corner" neighbours to their halo sizes after partitioning
-    std::vector<std::map<int, int>> _corner_neighbours_p = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _cornerNeighbours_p = std::vector<std::map<int, int>>(NNBRS);
 
     // Vector of maps of "corner" neighbours to their halo start indices after partitioning
-    std::vector<std::map<int, int>> _corner_send_pos_p = std::vector<std::map<int, int>>(NNBRS);
+    std::vector<std::map<int, int>> _cornerSendPos_p = std::vector<std::map<int, int>>(NNBRS);
 
 public:
     struct LIB_EXPORT Factory {
@@ -234,19 +234,19 @@ public:
      * @brief Check if two domains are neighbouring. If true, then domain 2 is the [edge] neighbour
      * of domain 1, relative to domain 1. e.g., if domain 2 is to the right of domain 1, the
      * following call will return true:
-     * is_neighbour(d1, d2, RIGHT)
+     * isNeighbour(d1, d2, RIGHT)
      *
      * @param d1 first domain
      * @param d2 second domain
      * @param edge LEFT, RIGHT, BOTTOM or TOP
-     * @param is_px are we looking for periodic neighbour in x-direction?
-     * @param is_py are we looking for periodic neighbour in y-direction?
+     * @param isPx are we looking for periodic neighbour in x-direction?
+     * @param isPy are we looking for periodic neighbour in y-direction?
      * @return bool
      */
-    bool is_neighbour(const Domain d1, const Domain d2, const Edge edge, const bool is_px = false,
-        const bool is_py = false);
-    bool is_corner_neighbour(const Domain d1, const Domain d2, const Corner corner,
-        const bool is_px = false, const bool is_py = false);
+    bool isNeighbour(const Domain d1, const Domain d2, const Edge edge, const bool isPx = false,
+        const bool isPy = false);
+    bool isCornerNeighbour(const Domain d1, const Domain d2, const Corner corner,
+        const bool isPx = false, const bool isPy = false);
 
     /*!
      * @brief Compute the sendPos and recvPos for halo exchange.

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -59,8 +59,8 @@ static void get_geometry_list(void* data, int num_gid_entries, int num_lid_entri
 
     // Use grid coordinates
     for (int i = 0; i < num_obj; i++) {
-        geom_vec[2 * i] = grid->get_nonzero_object_ids()[i] % grid->get_global_ext()[0];
-        geom_vec[2 * i + 1] = grid->get_nonzero_object_ids()[i] / grid->get_global_ext()[0];
+        geom_vec[2 * i] = grid->get_nonzero_object_ids()[i] % grid->getGlobalExt()[0];
+        geom_vec[2 * i + 1] = grid->get_nonzero_object_ids()[i] / grid->getGlobalExt()[0];
     }
 
     return;
@@ -93,28 +93,28 @@ ZoltanPartitioner* ZoltanPartitioner::create(MPI_Comm comm, int argc, char** arg
 void ZoltanPartitioner::partition(Grid& grid)
 {
     // Load initial grid state
-    _num_procs = grid.get_num_procs();
-    _global_ext = grid.get_global_ext();
-    grid.get_bounding_box(_global[0], _global[1], _local_ext[0], _local_ext[1]);
+    _numProcs = grid.getNumProcs();
+    _globalExt = grid.getGlobalExt();
+    grid.get_bounding_box(_global[0], _global[1], _localExt[0], _localExt[1]);
     _px = grid.get_px();
     _py = grid.get_py();
 
-    if (_total_num_procs == 1) {
+    if (_totalNumProcs == 1) {
         for (int idx = 0; idx < 2; idx++) {
-            _global_new[idx] = _global[idx];
-            _local_ext_new[idx] = _local_ext[idx];
+            _globalNew[idx] = _global[idx];
+            _localExtNew[idx] = _localExt[idx];
         }
 
         if (grid.get_num_objects() != grid.get_num_nonzero_objects()) {
             const int* land_mask = grid.get_land_mask();
-            _proc_id.resize(grid.get_num_objects(), -1);
+            _procId.resize(grid.get_num_objects(), -1);
             for (int i = 0; i < grid.get_num_objects(); i++) {
                 if (land_mask[i] > 0) {
-                    _proc_id[i] = _rank;
+                    _procId[i] = _rank;
                 }
             }
         } else {
-            _proc_id.resize(grid.get_num_objects(), _rank);
+            _procId.resize(grid.get_num_objects(), _rank);
         }
 
         return;
@@ -175,22 +175,22 @@ void ZoltanPartitioner::partition(Grid& grid)
         double maxs[3];
         _zoltan->RCB_Box(_rank, ndim, mins[0], mins[1], mins[2], maxs[0], maxs[1], maxs[2]);
         for (int idx = 0; idx < 2; idx++) {
-            _global_new[idx] = (mins[idx] == -DBL_MAX) ? 0 : std::ceil(mins[idx]);
-            int global_lower = (maxs[idx] == DBL_MAX) ? _global_ext[idx] : std::ceil(maxs[idx]);
-            _local_ext_new[idx] = global_lower - _global_new[idx];
+            _globalNew[idx] = (mins[idx] == -DBL_MAX) ? 0 : std::ceil(mins[idx]);
+            int global_lower = (maxs[idx] == DBL_MAX) ? _globalExt[idx] : std::ceil(maxs[idx]);
+            _localExtNew[idx] = global_lower - _globalNew[idx];
         }
     } else {
         for (int idx = 0; idx < 2; idx++) {
-            _global_new[idx] = _global[idx];
-            _local_ext_new[idx] = _local_ext[idx];
+            _globalNew[idx] = _global[idx];
+            _localExtNew[idx] = _localExt[idx];
         }
     }
 
     // Adapt to blocking
-    std::vector<int> global_ext_orig = grid.get_global_ext();
+    std::vector<int> globalExtOrig = grid.getGlobalExt();
     for (int idx = 0; idx < 2; idx++) {
-        if (_global_new[idx] + _local_ext_new[idx] > global_ext_orig[idx]) {
-            _local_ext_new[idx] = global_ext_orig[idx] - _global_new[idx];
+        if (_globalNew[idx] + _localExtNew[idx] > globalExtOrig[idx]) {
+            _localExtNew[idx] = globalExtOrig[idx] - _globalNew[idx];
         }
     }
 
@@ -200,21 +200,21 @@ void ZoltanPartitioner::partition(Grid& grid)
     // Find the process IDs of each grid point I own
     if (grid.get_num_objects() != grid.get_num_nonzero_objects()) {
         const int* land_mask = grid.get_land_mask();
-        _proc_id.resize(grid.get_num_objects(), -1);
+        _procId.resize(grid.get_num_objects(), -1);
         for (int i = 0; i < grid.get_num_objects(); i++) {
             if (land_mask[i] > 0) {
-                _proc_id[i] = _rank;
+                _procId[i] = _rank;
             }
         }
 
         const int* sparse_to_dense = grid.get_sparse_to_dense();
         for (int i = 0; i < num_export; i++) {
-            _proc_id[sparse_to_dense[export_local_ids[i]]] = export_procs[i];
+            _procId[sparse_to_dense[export_local_ids[i]]] = export_procs[i];
         }
     } else {
-        _proc_id.resize(grid.get_num_objects(), _rank);
+        _procId.resize(grid.get_num_objects(), _rank);
         for (int i = 0; i < num_export; i++) {
-            _proc_id[export_local_ids[i]] = export_procs[i];
+            _procId[export_local_ids[i]] = export_procs[i];
         }
     }
 

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -83,9 +83,9 @@ int main(int argc, char* argv[])
     partitioner->partition(*grid);
 
     // Retrieve neighbours
-    array<vector<int>, N_EDGE> ids, halos, halo_send, halo_recv;
+    array<vector<int>, N_EDGE> ids, halos, haloSend, haloRecv;
     array<vector<int>, N_CORNER> cornerIds, haloCornerStarts;
-    partitioner->get_neighbour_info(ids, halos, halo_send, halo_recv, cornerIds, haloCornerStarts);
+    partitioner->getNeighbourInfo(ids, halos, haloSend, haloRecv, cornerIds, haloCornerStarts);
 
     // MPI ranks of neighbours in order: top, bottom, left, right
     vector<int> ids_tblr(ids[3]);
@@ -107,11 +107,11 @@ int main(int argc, char* argv[])
     MPI_Comm_rank(comm_dist_graph, &mpi_rank);
 
     // Get information on my partition
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
 
     // Define data array
-    vector<double> data((local_ext_0 + 2) * (local_ext_1 + 2), mpi_rank);
+    vector<double> data((localExt0 + 2) * (localExt1 + 2), mpi_rank);
 
     // Define counts and displacements for MPI halo exchange
     vector<int> scounts(ids_tblr.size());
@@ -121,7 +121,7 @@ int main(int argc, char* argv[])
 
     // Define MPI derived datatypes
     const int ndims { 2 };
-    int sizes[ndims] = { local_ext_0 + 2, local_ext_1 + 2 };
+    int sizes[ndims] = { localExt0 + 2, localExt1 + 2 };
 
     // Send subarray types
     vector<MPI_Datatype> subar_top(ids[3].size());
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
     for (int i = 0; i < static_cast<int>(ids[2].size()); i++) {
         int subsizes[ndims] = { 1, halos[2][i] };
 
-        int send_bottom_start[ndims] = { local_ext_0, offset + 1 };
+        int send_bottom_start[ndims] = { localExt0, offset + 1 };
         MPI_Type_create_subarray(
             ndims, sizes, subsizes, send_bottom_start, MPI_ORDER_C, MPI_DOUBLE, &subar_bottom[i]);
         MPI_Type_commit(&subar_bottom[i]);
@@ -179,7 +179,7 @@ int main(int argc, char* argv[])
         scounts[cnt] = 1;
         sdispls[cnt] = 0;
 
-        int recv_bottom_start[ndims] = { local_ext_0 + 1, offset + 1 };
+        int recv_bottom_start[ndims] = { localExt0 + 1, offset + 1 };
         MPI_Type_create_subarray(
             ndims, sizes, subsizes, recv_bottom_start, MPI_ORDER_C, MPI_DOUBLE, &ghost_bottom[i]);
         MPI_Type_commit(&ghost_bottom[i]);
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
     for (int i = 0; i < static_cast<int>(ids[1].size()); i++) {
         int subsizes[ndims] = { halos[1][i], 1 };
 
-        int send_right_start[ndims] = { offset + 1, local_ext_1 };
+        int send_right_start[ndims] = { offset + 1, localExt1 };
         MPI_Type_create_subarray(
             ndims, sizes, subsizes, send_right_start, MPI_ORDER_C, MPI_DOUBLE, &subar_right[i]);
         MPI_Type_commit(&subar_right[i]);
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
         scounts[cnt] = 1;
         sdispls[cnt] = 0;
 
-        int recv_right_start[ndims] = { offset + 1, local_ext_1 + 1 };
+        int recv_right_start[ndims] = { offset + 1, localExt1 + 1 };
         MPI_Type_create_subarray(
             ndims, sizes, subsizes, recv_right_start, MPI_ORDER_C, MPI_DOUBLE, &ghost_right[i]);
         MPI_Type_commit(&ghost_right[i]);

--- a/examples/zoltan_comm.cpp
+++ b/examples/zoltan_comm.cpp
@@ -84,7 +84,7 @@ int main(int argc, char* argv[])
 
     // Retrieve neighbours
     array<vector<int>, N_EDGE> ids, halos, halo_send, halo_recv;
-    array<vector<int>, N_VERTEX> cornerIds, haloCornerStarts;
+    array<vector<int>, N_CORNER> cornerIds, haloCornerStarts;
     partitioner->get_neighbour_info(ids, halos, halo_send, halo_recv, cornerIds, haloCornerStarts);
 
     // MPI ranks of neighbours in order: top, bottom, left, right

--- a/main.cpp
+++ b/main.cpp
@@ -96,10 +96,10 @@ int main(int argc, char* argv[])
     partitioner->partition(*grid);
 
     // Store partitioning results in netCDF file
-    int num_procs;
-    MPI_Comm_size(comm, &num_procs);
-    partitioner->save_mask(prefix + "partition_mask_" + to_string(num_procs) + ".nc");
-    partitioner->save_metadata(prefix + "partition_metadata_" + to_string(num_procs) + ".nc");
+    int numProcs;
+    MPI_Comm_size(comm, &numProcs);
+    partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
+    partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
 
     // Cleanup
     delete grid;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,7 +33,7 @@ create_test(TARGET test_zoltan_0 SOURCES test_zoltan_partitioner_0.cpp)
 create_test(TARGET test_zoltan_1 SOURCES test_zoltan_partitioner_1.cpp)
 create_test(TARGET test_zoltan_2 SOURCES test_zoltan_partitioner_2.cpp)
 create_test(TARGET test_haloCornerBufferPositions SOURCES test_haloCornerBufferPositions.cpp)
-create_test(TARGET test_haloBufferPositions SOURCES test_haloBufferPositions.cpp)
+create_test(TARGET test_haloEdgeBufferPositions SOURCES test_haloEdgeBufferPositions.cpp)
 
 # Generate input files from respective cdl files
 add_custom_command(

--- a/test/test_grid_0.cpp
+++ b/test/test_grid_0.cpp
@@ -13,8 +13,8 @@ MPI_TEST_CASE("Grid: all land, 1 MPI rank", 1)
     // Build grid from netCDF file
     Grid* grid = Grid::create(test_comm, "./test_0.nc");
 
-    REQUIRE(grid->get_global_ext()[0] == 6);
-    REQUIRE(grid->get_global_ext()[1] == 4);
+    REQUIRE(grid->getGlobalExt()[0] == 6);
+    REQUIRE(grid->getGlobalExt()[1] == 4);
     REQUIRE(grid->get_num_nonzero_objects() == 0);
     REQUIRE(grid->get_num_objects() == 24);
 
@@ -32,8 +32,8 @@ MPI_TEST_CASE("Grid: all land, 2 MPI ranks", 2)
     // Build grid from netCDF file
     Grid* grid = Grid::create(test_comm, "./test_0.nc");
 
-    REQUIRE(grid->get_global_ext()[0] == 6);
-    REQUIRE(grid->get_global_ext()[1] == 4);
+    REQUIRE(grid->getGlobalExt()[0] == 6);
+    REQUIRE(grid->getGlobalExt()[1] == 4);
     REQUIRE(grid->get_num_nonzero_objects() == 0);
     REQUIRE(grid->get_num_objects() == 12);
 

--- a/test/test_grid_1.cpp
+++ b/test/test_grid_1.cpp
@@ -13,8 +13,8 @@ MPI_TEST_CASE("Grid: no land, 1 MPI rank", 1)
     // Build grid from netCDF file
     Grid* grid = Grid::create(test_comm, "./test_1.nc");
 
-    REQUIRE(grid->get_global_ext()[0] == 6);
-    REQUIRE(grid->get_global_ext()[1] == 4);
+    REQUIRE(grid->getGlobalExt()[0] == 6);
+    REQUIRE(grid->getGlobalExt()[1] == 4);
     REQUIRE(grid->get_num_objects() == 24);
     REQUIRE(grid->get_num_nonzero_objects() == 24);
 
@@ -32,8 +32,8 @@ MPI_TEST_CASE("Grid: no land, 2 MPI ranks", 2)
     // Build grid from netCDF file
     Grid* grid = Grid::create(test_comm, "./test_1.nc");
 
-    REQUIRE(grid->get_global_ext()[0] == 6);
-    REQUIRE(grid->get_global_ext()[1] == 4);
+    REQUIRE(grid->getGlobalExt()[0] == 6);
+    REQUIRE(grid->getGlobalExt()[1] == 4);
     REQUIRE(grid->get_num_objects() == 12);
     REQUIRE(grid->get_num_nonzero_objects() == 12);
 

--- a/test/test_grid_2.cpp
+++ b/test/test_grid_2.cpp
@@ -13,14 +13,14 @@ MPI_TEST_CASE("Grid: non-default dimension naming, 1 MPI rank", 1)
     // Build grid from netCDF file
     Grid* grid = Grid::create(test_comm, "./test_2.nc", "m", "n", { 1, 0 }, "land_mask");
 
-    REQUIRE(grid->get_global_ext()[0] == 6);
-    REQUIRE(grid->get_global_ext()[1] == 4);
+    REQUIRE(grid->getGlobalExt()[0] == 6);
+    REQUIRE(grid->getGlobalExt()[1] == 4);
     REQUIRE(grid->get_num_objects() == 24);
     REQUIRE(grid->get_num_nonzero_objects() == 12);
 
     const int* mask = grid->get_land_mask();
     for (int i = 0; i < grid->get_num_objects(); i++) {
-        if ((i / grid->get_local_ext()[0]) % 2 == 0) {
+        if ((i / grid->getLocalExt()[0]) % 2 == 0) {
             REQUIRE(mask[i] == 0);
         }
     }
@@ -34,14 +34,14 @@ MPI_TEST_CASE("Grid: non-default dimension naming, 2 MPI ranks", 2)
     // Build grid from netCDF file
     Grid* grid = Grid::create(test_comm, "./test_2.nc", "m", "n", { 1, 0 }, "land_mask");
 
-    REQUIRE(grid->get_global_ext()[0] == 6);
-    REQUIRE(grid->get_global_ext()[1] == 4);
+    REQUIRE(grid->getGlobalExt()[0] == 6);
+    REQUIRE(grid->getGlobalExt()[1] == 4);
     REQUIRE(grid->get_num_objects() == 12);
     REQUIRE(grid->get_num_nonzero_objects() == 6);
 
     const int* mask = grid->get_land_mask();
     for (int i = 0; i < grid->get_num_objects(); i++) {
-        if ((i / grid->get_local_ext()[0]) % 2 == 0) {
+        if ((i / grid->getLocalExt()[0]) % 2 == 0) {
             REQUIRE(mask[i] == 0);
         }
     }

--- a/test/test_haloCornerBufferPositions.cpp
+++ b/test/test_haloCornerBufferPositions.cpp
@@ -69,7 +69,7 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
 
     const bool pxOn = true, pyOn = true;
 
-    std::map<Vertex, HaloCornerInfo> cornerInfoExpected, cornerInfoActual;
+    std::map<Corner, HaloCornerInfo> cornerInfoExpected, cornerInfoActual;
 
     if (test_rank == 0) {
         cornerInfoExpected[BOTTOM_LEFT] = { true, 3, 5 };
@@ -93,7 +93,7 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
         cornerInfoExpected[TOP_LEFT] = { true, 0, 3 };
     }
 
-    for (auto corner : vertices) {
+    for (auto corner : corners) {
         for (int p = 0; p < test_nb_procs; p++) {
             // periodic neighbours
             if (partitioner->is_corner_neighbour(
@@ -113,7 +113,7 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
         }
     }
 
-    for (auto corner : vertices) {
+    for (auto corner : corners) {
         // check computed corner info (actual) against the expected information
         REQUIRE(cornerInfoActual[corner].isPeriodic == cornerInfoExpected[corner].isPeriodic);
         REQUIRE(cornerInfoActual[corner].rank == cornerInfoExpected[corner].rank);

--- a/test/test_haloCornerBufferPositions.cpp
+++ b/test/test_haloCornerBufferPositions.cpp
@@ -24,8 +24,8 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
 
     // Gather bounding boxes for all processes
     std::vector<Point> origins(test_nb_procs);
@@ -34,8 +34,8 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
     std::vector<int> tmp0(test_nb_procs);
     std::vector<int> tmp1(test_nb_procs);
 
-    CHECK_MPI(MPI_Allgather(&global_0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
-    CHECK_MPI(MPI_Allgather(&global_1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&global0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&global1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
 
     // origin points mark the bottom-left corner of each domain
     for (int p = 0; p < test_nb_procs; p++) {
@@ -43,8 +43,8 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
         origins[p].y = tmp1[p];
     }
 
-    CHECK_MPI(MPI_Allgather(&local_ext_0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
-    CHECK_MPI(MPI_Allgather(&local_ext_1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&localExt0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&localExt1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
 
     // extents can be used to find the top-right corner of each domain
     for (int p = 0; p < test_nb_procs; p++) {
@@ -96,7 +96,7 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
     for (auto corner : corners) {
         for (int p = 0; p < test_nb_procs; p++) {
             // periodic neighbours
-            if (partitioner->is_corner_neighbour(
+            if (partitioner->isCornerNeighbour(
                     domains[test_rank], domains[p], corner, pxOn, pyOn)) {
                 partitioner->haloCornerBufferPositions(
                     domains[test_rank], domains[p], corner, start);
@@ -104,7 +104,7 @@ MPI_TEST_CASE("test corner neighbours and metadata for corner buffers", 4)
             }
             // non-periodic neighbours
             if (p != test_rank) {
-                if (partitioner->is_corner_neighbour(domains[test_rank], domains[p], corner)) {
+                if (partitioner->isCornerNeighbour(domains[test_rank], domains[p], corner)) {
                     partitioner->haloCornerBufferPositions(
                         domains[test_rank], domains[p], corner, start);
                     cornerInfoActual[corner] = { false, p, start };

--- a/test/test_haloEdgeBufferPositions.cpp
+++ b/test/test_haloEdgeBufferPositions.cpp
@@ -1,5 +1,5 @@
 /*!
- * @file test_haloBufferPositions.cpp
+ * @file test_haloEdgeBufferPositions.cpp
  * @author Nirav Shah <nvs31@cam.ac.uk>
  * @date 19 January 2026
  */
@@ -108,7 +108,7 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
             // periodic neighbours
             if (p != test_rank) {
                 if (partitioner->is_neighbour(domains[test_rank], domains[p], edge, pxOn, pyOn)) {
-                    partitioner->haloBufferPositions(
+                    partitioner->haloEdgeBufferPositions(
                         domains[test_rank], domains[p], edge, start, recv);
                     edgeInfoActual[edge].push_back({ true, p, start, recv });
                 }
@@ -117,7 +117,7 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
             // non-periodic neighbours
             if (p != test_rank) {
                 if (partitioner->is_neighbour(domains[test_rank], domains[p], edge)) {
-                    partitioner->haloBufferPositions(
+                    partitioner->haloEdgeBufferPositions(
                         domains[test_rank], domains[p], edge, start, recv);
                     edgeInfoActual[edge].push_back({ false, p, start, recv });
                 }

--- a/test/test_haloEdgeBufferPositions.cpp
+++ b/test/test_haloEdgeBufferPositions.cpp
@@ -74,7 +74,7 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
 
     // The int in tuple<Edge, int> refers to rank. In the case of edge neighbours,
     // it is possible that one edge may corresspond to multiple neighbour unlike
-    // corner neighbour where a given vertice can correspond to only one neighbour.
+    // corner neighbour where a given corner can correspond to only one neighbour.
     std::map<Edge, std::vector<HaloEdgeInfo>> edgeInfoExpected, edgeInfoActual;
 
     if (test_rank == 0) {

--- a/test/test_haloEdgeBufferPositions.cpp
+++ b/test/test_haloEdgeBufferPositions.cpp
@@ -24,8 +24,8 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
 
     // Gather bounding boxes for all processes
     std::vector<Point> origins(test_nb_procs);
@@ -34,8 +34,8 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
     std::vector<int> tmp0(test_nb_procs);
     std::vector<int> tmp1(test_nb_procs);
 
-    CHECK_MPI(MPI_Allgather(&global_0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
-    CHECK_MPI(MPI_Allgather(&global_1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&global0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&global1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
 
     // origin points mark the bottom-left corner of each domain
     for (int p = 0; p < test_nb_procs; p++) {
@@ -43,8 +43,8 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
         origins[p].y = tmp1[p];
     }
 
-    CHECK_MPI(MPI_Allgather(&local_ext_0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
-    CHECK_MPI(MPI_Allgather(&local_ext_1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&localExt0, 1, MPI_INT, tmp0.data(), 1, MPI_INT, test_comm));
+    CHECK_MPI(MPI_Allgather(&localExt1, 1, MPI_INT, tmp1.data(), 1, MPI_INT, test_comm));
 
     // extents can be used to find the top-right corner of each domain
     for (int p = 0; p < test_nb_procs; p++) {
@@ -107,7 +107,7 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
         for (int p = 0; p < test_nb_procs; p++) {
             // periodic neighbours
             if (p != test_rank) {
-                if (partitioner->is_neighbour(domains[test_rank], domains[p], edge, pxOn, pyOn)) {
+                if (partitioner->isNeighbour(domains[test_rank], domains[p], edge, pxOn, pyOn)) {
                     partitioner->haloEdgeBufferPositions(
                         domains[test_rank], domains[p], edge, start, recv);
                     edgeInfoActual[edge].push_back({ true, p, start, recv });
@@ -116,7 +116,7 @@ MPI_TEST_CASE("test edge neighbours and metadata for edge buffers", 4)
 
             // non-periodic neighbours
             if (p != test_rank) {
-                if (partitioner->is_neighbour(domains[test_rank], domains[p], edge)) {
+                if (partitioner->isNeighbour(domains[test_rank], domains[p], edge)) {
                     partitioner->haloEdgeBufferPositions(
                         domains[test_rank], domains[p], edge, start, recv);
                     edgeInfoActual[edge].push_back({ false, p, start, recv });

--- a/test/test_zoltan_partitioner_0.cpp
+++ b/test/test_zoltan_partitioner_0.cpp
@@ -24,12 +24,12 @@ MPI_TEST_CASE("ZoltanPartitioner: all land, 1 MPI rank", 1)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 6);
-    REQUIRE(local_ext_1 == 4);
-    REQUIRE(global_0 == 0);
-    REQUIRE(global_1 == 0);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 6);
+    REQUIRE(localExt1 == 4);
+    REQUIRE(global0 == 0);
+    REQUIRE(global1 == 0);
 
     // Cleanup
     delete grid;
@@ -48,16 +48,16 @@ MPI_TEST_CASE("ZoltanPartitioner: all land, 2 MPI ranks", 2)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 3);
-    REQUIRE(local_ext_1 == 4);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 3);
+    REQUIRE(localExt1 == 4);
     if (test_rank == 0) {
-        REQUIRE(global_0 == 0);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 0);
+        REQUIRE(global1 == 0);
     } else {
-        REQUIRE(global_0 == 3);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 3);
+        REQUIRE(global1 == 0);
     }
 
     // Cleanup

--- a/test/test_zoltan_partitioner_1.cpp
+++ b/test/test_zoltan_partitioner_1.cpp
@@ -24,12 +24,12 @@ MPI_TEST_CASE("ZoltanPartitioner: no land, 1 MPI rank", 1)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 6);
-    REQUIRE(local_ext_1 == 4);
-    REQUIRE(global_0 == 0);
-    REQUIRE(global_1 == 0);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 6);
+    REQUIRE(localExt1 == 4);
+    REQUIRE(global0 == 0);
+    REQUIRE(global1 == 0);
 
     // Cleanup
     delete grid;
@@ -48,16 +48,16 @@ MPI_TEST_CASE("ZoltanPartitioner: no land, 2 MPI ranks", 2)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 3);
-    REQUIRE(local_ext_1 == 4);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 3);
+    REQUIRE(localExt1 == 4);
     if (test_rank == 0) {
-        REQUIRE(global_0 == 0);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 0);
+        REQUIRE(global1 == 0);
     } else {
-        REQUIRE(global_0 == 3);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 3);
+        REQUIRE(global1 == 0);
     }
 
     // Cleanup

--- a/test/test_zoltan_partitioner_2.cpp
+++ b/test/test_zoltan_partitioner_2.cpp
@@ -24,12 +24,12 @@ MPI_TEST_CASE("ZoltanPartitioner: non-default dimension naming, 1 MPI rank", 1)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 6);
-    REQUIRE(local_ext_1 == 4);
-    REQUIRE(global_0 == 0);
-    REQUIRE(global_1 == 0);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 6);
+    REQUIRE(localExt1 == 4);
+    REQUIRE(global0 == 0);
+    REQUIRE(global1 == 0);
 
     // Cleanup
     delete grid;
@@ -48,16 +48,16 @@ MPI_TEST_CASE("ZoltanPartitioner: non-default dimension naming, 2 MPI ranks", 2)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 3);
-    REQUIRE(local_ext_1 == 4);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 3);
+    REQUIRE(localExt1 == 4);
     if (test_rank == 0) {
-        REQUIRE(global_0 == 0);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 0);
+        REQUIRE(global1 == 0);
     } else {
-        REQUIRE(global_0 == 3);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 3);
+        REQUIRE(global1 == 0);
     }
 
     // Cleanup
@@ -77,19 +77,19 @@ MPI_TEST_CASE("ZoltanPartitioner: non-default dimension naming, 3 MPI ranks", 3)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
-    REQUIRE(local_ext_0 == 2);
-    REQUIRE(local_ext_1 == 4);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
+    REQUIRE(localExt0 == 2);
+    REQUIRE(localExt1 == 4);
     if (test_rank == 0) {
-        REQUIRE(global_0 == 0);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 0);
+        REQUIRE(global1 == 0);
     } else if (test_rank == 1) {
-        REQUIRE(global_0 == 2);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 2);
+        REQUIRE(global1 == 0);
     } else {
-        REQUIRE(global_0 == 4);
-        REQUIRE(global_1 == 0);
+        REQUIRE(global0 == 4);
+        REQUIRE(global1 == 0);
     }
 
     // Cleanup
@@ -109,28 +109,28 @@ MPI_TEST_CASE("ZoltanPartitioner: non-default dimension naming, 4 MPI ranks", 4)
     // Partition grid
     partitioner->partition(*grid);
 
-    int global_0, global_1, local_ext_0, local_ext_1;
-    partitioner->get_bounding_box(global_0, global_1, local_ext_0, local_ext_1);
+    int global0, global1, localExt0, localExt1;
+    partitioner->getBoundingBox(global0, global1, localExt0, localExt1);
     if (test_rank == 0) {
-        REQUIRE(local_ext_0 == 1);
-        REQUIRE(local_ext_1 == 4);
-        REQUIRE(global_0 == 0);
-        REQUIRE(global_1 == 0);
+        REQUIRE(localExt0 == 1);
+        REQUIRE(localExt1 == 4);
+        REQUIRE(global0 == 0);
+        REQUIRE(global1 == 0);
     } else if (test_rank == 1) {
-        REQUIRE(local_ext_0 == 2);
-        REQUIRE(local_ext_1 == 4);
-        REQUIRE(global_0 == 1);
-        REQUIRE(global_1 == 0);
+        REQUIRE(localExt0 == 2);
+        REQUIRE(localExt1 == 4);
+        REQUIRE(global0 == 1);
+        REQUIRE(global1 == 0);
     } else if (test_rank == 2) {
-        REQUIRE(local_ext_0 == 1);
-        REQUIRE(local_ext_1 == 4);
-        REQUIRE(global_0 == 3);
-        REQUIRE(global_1 == 0);
+        REQUIRE(localExt0 == 1);
+        REQUIRE(localExt1 == 4);
+        REQUIRE(global0 == 3);
+        REQUIRE(global1 == 0);
     } else {
-        REQUIRE(local_ext_0 == 2);
-        REQUIRE(local_ext_1 == 4);
-        REQUIRE(global_0 == 4);
-        REQUIRE(global_1 == 0);
+        REQUIRE(localExt0 == 2);
+        REQUIRE(localExt1 == 4);
+        REQUIRE(global0 == 4);
+        REQUIRE(global1 == 0);
     }
 
     // Cleanup


### PR DESCRIPTION
# Cosmetic changes

fixes #80 

> [!NOTE]
> **This PR is only cosmetic**. No functionality was intentionally changed. All the tests continue to pass. 

## Summary
- Renamed variables from snake_case to camelCase for consistency with C++ naming conventions
- Updated function names and parameters throughout the codebase
- Ensured all references to renamed variables are updated

The following cosmetic changes have been made to `domain_decomp`

- [x] Uniform(ize)d the variable names and naming conventions.
- [x] rename `haloBufferPositions` to `haloEdgeBufferPositions`
- [x] change `vertex` to `corner`
- [x] use CamelCase instead of underscores to bring in-line with nextsim

---

## Renamed variables, functions, methods etc.

- `get_width()` → `getWidth()`
- `get_height()` → `getHeight()`
- `domain_overlap()` → `domainOverlap()`
- `global_ext` → `globalExt`
- `local_ext` → `localExt`
- `total_num_procs` → `totalNumProcs`
- `num_procs` → `numProcs`
- `is_neighbour()` → `isNeighbour()`
- `is_corner_neighbour()` → `isCornerNeighbour()`
- `send_pos` → `sendPos`
- `recv_pos` → `recvPos`
- `get_bounding_box()` → `getBoundingBox()`
- `get_neighbour_info()` → `getNeighbourInfo()`
- `get_neighbour_info_periodic()` → `getNeighbourInfoPeriodic()`
- `save_mask()` → `saveMask()`
- `save_metadata()` → `saveMetadata()`
- `global_0` → `global0`
- `global_1` → `global1`
- `local_ext_0` → `localExt0`
- `local_ext_1` → `localExt1`
- `halo_sizes` → `haloSizes`
- `halo_send` → `haloSend`
- `halo_recv` → `haloRecv`
- `corner_ids` → `cornerIds`
- `corner_send` → `cornerSend`
- `num_corner_neighbours` → `numCornerNeighbours`
- `corner_send_pos` → `cornerSendPos`
- `global_ext_new` → `globalExtNew`
- `local_ext_new` → `localExtNew`
- `proc_id` → `procId`
- `global_extent_names` → `globalExtentNames`
- `corner_neighbours` → `cornerNeighbours`
- `corner_send_pos_p` → `cornerSendPos_p`
- `corner_neighbours_p` → `cornerNeighbours_p`
- `send_pos_p` → `sendPos_p`
- `recv_pos_p` → `recvPos_p`
