### PR TITLE
Add command arguments to metadata

### DIFF
--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -242,7 +242,7 @@ void Partitioner::haloCornerBufferPositions(
     }
 }
 
-void Partitioner::setCommand(const std::string& command) { _command = command; }
+void Partitioner::setArgs(const std::string& args) { _args = args; }
 
 Partitioner::Partitioner(MPI_Comm comm)
 {
@@ -452,9 +452,9 @@ void Partitioner::saveMetadata(const std::string& filename) const
     // ---- Write ----
     NC_CHECK(nc_enddef(nc_id));
 
-    // Write command as a global string attribute
-    if (!_command.empty()) {
-        NC_CHECK(nc_put_att_text(nc_id, NC_GLOBAL, "command", _command.size(), _command.c_str()));
+    // Write args as a global string attribute
+    if (!_args.empty()) {
+        NC_CHECK(nc_put_att_text(nc_id, NC_GLOBAL, "args", _args.size(), _args.c_str()));
     }
 
     // Bounding boxes: one value per process

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -4,8 +4,8 @@
  * @date 05 Nov 2024
  */
 
-#include "Partitioner.hpp"
 #include "DomainUtils.hpp"
+#include "Partitioner.hpp"
 #include "Utils.hpp"
 #include "ZoltanPartitioner.hpp"
 
@@ -242,6 +242,8 @@ void Partitioner::haloCornerBufferPositions(
     }
 }
 
+void Partitioner::setCommand(const std::string& command) { _command = command; }
+
 Partitioner::Partitioner(MPI_Comm comm)
 {
     _comm = comm;
@@ -449,6 +451,11 @@ void Partitioner::saveMetadata(const std::string& filename) const
 
     // ---- Write ----
     NC_CHECK(nc_enddef(nc_id));
+
+    // Write command as a global string attribute
+    if (!_command.empty()) {
+        NC_CHECK(nc_put_att_text(nc_id, NC_GLOBAL, "command", _command.size(), _command.c_str()));
+    }
 
     // Bounding boxes: one value per process
     for (int idx = 0; idx < Partitioner::NDIMS; idx++) {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -37,14 +37,14 @@ public:
     virtual ~Partitioner() {};
 
     /*!
-     * @brief Store command line that produced the metadata.
+     * @brief Store command line arguments that produced the metadata.
      *
-     * @param command The full command string (e.g., "decomp -x xdim -y ydim -g grid.nc ...")
+     * @param args The arguments string (e.g., "-x xdim -y ydim -g grid.nc ...")
      *
      * Note: it is not possible to store the MPI launch part e.g., "mpirun -n 8 decomp ..." as this
-     * is stripped by the launcher. Only the decomp arguments are received by decomp.
+     * is stripped by the launcher. Only the arguments passed to decomp are stored.
      */
-    void setCommand(const std::string& command);
+    void setArgs(const std::string& args);
 
     /*!
      * @brief Partitions a 2D grid into rectangular boxes, one per process.
@@ -192,8 +192,8 @@ protected:
     // Vector of maps of "corner" neighbours to their halo start indices after partitioning
     std::vector<std::map<int, int>> _cornerSendPos = std::vector<std::map<int, int>>(NNBRS);
 
-    // Full command line that produced the metadata
-    std::string _command = "";
+    // Command line arguments that produced the metadata
+    std::string _args = "";
 
 public:
     struct LIB_EXPORT Factory {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -37,6 +37,16 @@ public:
     virtual ~Partitioner() {};
 
     /*!
+     * @brief Store command line that produced the metadata.
+     *
+     * @param command The full command string (e.g., "decomp -x xdim -y ydim -g grid.nc ...")
+     *
+     * Note: it is not possible to store the MPI launch part e.g., "mpirun -n 8 decomp ..." as this
+     * is stripped by the launcher. Only the decomp arguments are received by decomp.
+     */
+    void setCommand(const std::string& command);
+
+    /*!
      * @brief Partitions a 2D grid into rectangular boxes, one per process.
      *
      * Partitions a 2D grid into rectangular boxes, one per process, taking into
@@ -181,6 +191,9 @@ protected:
 
     // Vector of maps of "corner" neighbours to their halo start indices after partitioning
     std::vector<std::map<int, int>> _cornerSendPos = std::vector<std::map<int, int>>(NNBRS);
+
+    // Full command line that produced the metadata
+    std::string _command = "";
 
 public:
     struct LIB_EXPORT Factory {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -41,8 +41,6 @@ public:
      *
      * @param args The arguments string (e.g., "-x xdim -y ydim -g grid.nc ...")
      *
-     * Note: it is not possible to store the MPI launch part e.g., "mpirun -n 8 decomp ..." as this
-     * is stripped by the launcher. Only the arguments passed to decomp are stored.
      */
     void setArgs(const std::string& args);
 

--- a/main.cpp
+++ b/main.cpp
@@ -92,20 +92,20 @@ int main(int argc, char* argv[])
     Partitioner* partitioner
         = Partitioner::Factory::create(comm, argc, argv, PartitionerType::Zoltan_RCB);
 
-    // Build the full command string from argc/argv
-    std::string command;
-    for (int i = 0; i < argc; i++) {
-        if (i > 0) command += " ";
-        command += argv[i];
+    // Build the arguments string from argc/argv (skip argv[0], the binary name)
+    std::string args;
+    for (int i = 1; i < argc; i++) {
+        if (i > 1) args += " ";
+        args += argv[i];
     }
 
     // Partition grid
     partitioner->partition(*grid);
 
-    // Store command and partitioning results in netCDF file
+    // Store args and partitioning results in netCDF file
     int numProcs;
     MPI_Comm_size(comm, &numProcs);
-    partitioner->setCommand(command);
+    partitioner->setArgs(args);
     partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
     partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
 

--- a/main.cpp
+++ b/main.cpp
@@ -93,11 +93,14 @@ int main(int argc, char* argv[])
         = Partitioner::Factory::create(comm, argc, argv, PartitionerType::Zoltan_RCB);
 
     // Build the arguments string from argc/argv (skip argv[0], the binary name)
-    std::string args;
-    for (int i = 1; i < argc; i++) {
-        if (i > 1) args += " ";
-        args += argv[i];
-    }
+    const std::string args = [&]() {
+       std::string out;
+       for (int i = 1; i < argc; i++ ) {
+           if (i > 1) out += " ";
+           out += argv[i];
+       }
+       return out;
+    }();
 
     // Partition grid
     partitioner->partition(*grid);

--- a/main.cpp
+++ b/main.cpp
@@ -92,12 +92,20 @@ int main(int argc, char* argv[])
     Partitioner* partitioner
         = Partitioner::Factory::create(comm, argc, argv, PartitionerType::Zoltan_RCB);
 
+    // Build the full command string from argc/argv
+    std::string command;
+    for (int i = 0; i < argc; i++) {
+        if (i > 0) command += " ";
+        command += argv[i];
+    }
+
     // Partition grid
     partitioner->partition(*grid);
 
-    // Store partitioning results in netCDF file
+    // Store command and partitioning results in netCDF file
     int numProcs;
     MPI_Comm_size(comm, &numProcs);
+    partitioner->setCommand(command);
     partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
     partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
 

--- a/test/test_1/ref_partition_metadata_3.cdl
+++ b/test/test_1/ref_partition_metadata_3.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = UNLIMITED ; // (0 currently)
 
 // global attributes:
-		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx" ;
+		:args = "-g test_1.nc -x x -y y -m mask -o yx" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_1/ref_partition_metadata_3.cdl
+++ b/test/test_1/ref_partition_metadata_3.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 1 ;
 	BL = UNLIMITED ; // (0 currently)
 
+// global attributes:
+		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_1_px/ref_partition_metadata_3.cdl
+++ b/test/test_1_px/ref_partition_metadata_3.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 1 ;
 
 // global attributes:
-		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx --px" ;
+		:args = "-g test_1.nc -x x -y y -m mask -o yx --px" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_1_px/ref_partition_metadata_3.cdl
+++ b/test/test_1_px/ref_partition_metadata_3.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 1 ;
 	BL = 1 ;
 
+// global attributes:
+		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx --px" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_1_px_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_px_py/ref_partition_metadata_3.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 3 ;
 
 // global attributes:
-		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx --px --py" ;
+		:args = "-g test_1.nc -x x -y y -m mask -o yx --px --py" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_1_px_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_px_py/ref_partition_metadata_3.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 3 ;
 	BL = 3 ;
 
+// global attributes:
+		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx --px --py" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_1_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_py/ref_partition_metadata_3.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 1 ;
 
 // global attributes:
-		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx --py" ;
+		:args = "-g test_1.nc -x x -y y -m mask -o yx --py" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_1_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_py/ref_partition_metadata_3.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 2 ;
 	BL = 1 ;
 
+// global attributes:
+		:command = "../decomp -g test_1.nc -x x -y y -m mask -o yx --py" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_2/ref_partition_metadata_3.cdl
+++ b/test/test_2/ref_partition_metadata_3.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = UNLIMITED ; // (0 currently)
 
 // global attributes:
-		:command = "../decomp -g test_2.nc -x m -y n -m land_mask -o yx" ;
+		:args = "-g test_2.nc -x m -y n -m land_mask -o yx" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_2/ref_partition_metadata_3.cdl
+++ b/test/test_2/ref_partition_metadata_3.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = UNLIMITED ; // (0 currently)
 	BL = UNLIMITED ; // (0 currently)
 
+// global attributes:
+		:command = "../decomp -g test_2.nc -x m -y n -m land_mask -o yx" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_3/ref_partition_metadata_4.cdl
+++ b/test/test_3/ref_partition_metadata_4.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 1 ;
 	BL = 1 ;
 
+// global attributes:
+		:command = "../decomp -g test_3.nc -x x -y y -m mask -o yx" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_3/ref_partition_metadata_4.cdl
+++ b/test/test_3/ref_partition_metadata_4.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 1 ;
 
 // global attributes:
-		:command = "../decomp -g test_3.nc -x x -y y -m mask -o yx" ;
+		:args = "-g test_3.nc -x x -y y -m mask -o yx" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_4/ref_partition_metadata_4.cdl
+++ b/test/test_4/ref_partition_metadata_4.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 1 ;
 
 // global attributes:
-		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx" ;
+		:args = "-g test_4.nc -x x -y y -m land_mask -o yx" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_4/ref_partition_metadata_4.cdl
+++ b/test/test_4/ref_partition_metadata_4.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 1 ;
 	BL = 1 ;
 
+// global attributes:
+		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_4_px/ref_partition_metadata_4.cdl
+++ b/test/test_4_px/ref_partition_metadata_4.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 2 ;
 
 // global attributes:
-		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx --px" ;
+		:args = "-g test_4.nc -x x -y y -m land_mask -o yx --px" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_4_px/ref_partition_metadata_4.cdl
+++ b/test/test_4_px/ref_partition_metadata_4.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 2 ;
 	BL = 2 ;
 
+// global attributes:
+		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx --px" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_4_px_py/ref_partition_metadata_4.cdl
+++ b/test/test_4_px_py/ref_partition_metadata_4.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 4 ;
 
 // global attributes:
-		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx --px --py" ;
+		:args = "-g test_4.nc -x x -y y -m land_mask -o yx --px --py" ;
 
 group: bounding_boxes {
   variables:

--- a/test/test_4_px_py/ref_partition_metadata_4.cdl
+++ b/test/test_4_px_py/ref_partition_metadata_4.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 4 ;
 	BL = 4 ;
 
+// global attributes:
+		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx --px --py" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_4_py/ref_partition_metadata_4.cdl
+++ b/test/test_4_py/ref_partition_metadata_4.cdl
@@ -12,6 +12,9 @@ dimensions:
 	BR = 2 ;
 	BL = 2 ;
 
+// global attributes:
+		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx --py" ;
+
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;

--- a/test/test_4_py/ref_partition_metadata_4.cdl
+++ b/test/test_4_py/ref_partition_metadata_4.cdl
@@ -13,7 +13,7 @@ dimensions:
 	BL = 2 ;
 
 // global attributes:
-		:command = "../decomp -g test_4.nc -x x -y y -m land_mask -o yx --py" ;
+		:args = "-g test_4.nc -x x -y y -m land_mask -o yx --py" ;
 
 group: bounding_boxes {
   variables:


### PR DESCRIPTION
# Store command line args in partition metadata netCDF files

Relates to a sub-component of #86

## Summary
Adds the decomp tool command line arguments, used to invoke `decomp` as a global `command` attribute in all partition metadata netCDF files. This improves reproducibility making it easier to see which args `decomp` used to produce a given metadata output.

## Changes
- **Partitioner** — Added `setArgs()` method and `_args` member to store and write the args string
- **main.cpp** — Rebuilds the full `argc/argv` arguments string and passes it to the partitioner before saving metadata
- **Tests** — Updated all 10 partition metadata reference CDL files to include the expected `args` attribute

> [!NOTE]
> It is not possible to store the MPI launch part e.g., `mpirun -n 8 decomp ...` as is stripped by the launcher. Only the `decomp` arguments are received by `decomp`. As a result we have decided to store args only.
 
