### PR TITLE
Split comm method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 Testing
 *.DS_Store
 *.nc
+.cache/

--- a/Grid.cpp
+++ b/Grid.cpp
@@ -257,6 +257,11 @@ void Grid::set_global(const std::vector<int>& global)
     _global = global;
 }
 
+void Grid::set_comm(MPI_Comm comm)
+{
+    _comm = comm;
+}
+
 void Grid::set_globalExt(const std::vector<int>& globalExt)
 {
     _globalExt = globalExt;

--- a/Grid.cpp
+++ b/Grid.cpp
@@ -137,6 +137,7 @@ Grid::Grid(MPI_Comm comm, const std::string& filename, const std::string& xdim_n
     , _dim_order(dim_order)
     , _px(px)
     , _py(py)
+    , _ignore_mask(ignore_mask)
 {
 
     CHECK_MPI(MPI_Comm_rank(comm, &_rank));
@@ -225,4 +226,66 @@ void Grid::get_bounding_box(int& global0, int& global1, int& localExt0, int& loc
     global1 = _global[1];
     localExt0 = _localExt[0];
     localExt1 = _localExt[1];
+}
+
+// Copy constructor
+Grid::Grid(const Grid& other)
+    : _comm(other._comm)
+    , _rank(other._rank)
+    , _totalNumProcs(other._totalNumProcs)
+    , _numProcs(other._numProcs)
+    , _globalExt(other._globalExt)
+    , _localExt(other._localExt)
+    , _global(other._global)
+    , _localExtNew(other._localExtNew)
+    , _globalNew(other._globalNew)
+    , _dim_names(other._dim_names)
+    , _dim_order(other._dim_order)
+    , _num_objects(other._num_objects)
+    , _num_nonzero_objects(other._num_nonzero_objects)
+    , _px(other._px)
+    , _py(other._py)
+    , _ignore_mask(other._ignore_mask)
+    , _land_mask(other._land_mask)
+    , _local_id(other._local_id)
+    , _global_id(other._global_id)
+{
+}
+
+void Grid::set_global(const std::vector<int>& global)
+{
+    _global = global;
+}
+
+void Grid::set_globalExt(const std::vector<int>& globalExt)
+{
+    _globalExt = globalExt;
+}
+
+void Grid::recompute_ids()
+{
+    _global_id.clear();
+    _local_id.clear();
+    _num_nonzero_objects = 0;
+    _num_objects = _localExt[0] * _localExt[1];
+
+    if (!_ignore_mask) {
+        for (int i = 0; i < _num_objects; i++) {
+            if (_land_mask[i] > 0) {
+                int temp_i = i % _localExt[0] + _global[0];
+                int temp_j = i / _localExt[0] + _global[1];
+                _global_id.push_back(temp_j * _globalExt[0] + temp_i);
+                _local_id.push_back(i);
+                _num_nonzero_objects++;
+            }
+        }
+    } else {
+        _num_nonzero_objects = _num_objects;
+        for (int i = 0; i < _num_objects; i++) {
+            int temp_i = i % _localExt[0];
+            int temp_j = i / _localExt[0];
+            _global_id.push_back(temp_j * _globalExt[0] + _global[0] + temp_i);
+            _local_id.push_back(i);
+        }
+    }
 }

--- a/Grid.cpp
+++ b/Grid.cpp
@@ -252,20 +252,11 @@ Grid::Grid(const Grid& other)
 {
 }
 
-void Grid::set_global(const std::vector<int>& global)
-{
-    _global = global;
-}
+void Grid::set_global(const std::vector<int>& global) { _global = global; }
 
-void Grid::set_comm(MPI_Comm comm)
-{
-    _comm = comm;
-}
+void Grid::set_comm(MPI_Comm comm) { _comm = comm; }
 
-void Grid::set_globalExt(const std::vector<int>& globalExt)
-{
-    _globalExt = globalExt;
-}
+void Grid::set_globalExt(const std::vector<int>& globalExt) { _globalExt = globalExt; }
 
 void Grid::recompute_ids()
 {

--- a/Grid.hpp
+++ b/Grid.hpp
@@ -32,9 +32,11 @@ class LIB_EXPORT Grid {
     const std::string data_id = "data";
 
 public:
-    // Disallow compiler-generated special functions
-    Grid(const Grid&) = delete;
+    // Disallow compiler-generated assignment
     Grid& operator=(const Grid&) = delete;
+
+    // Copy constructor (member data copied, const members initialised in ctor list)
+    Grid(const Grid& other);
 
     /*!
      * @brief Destructor.
@@ -176,6 +178,26 @@ public:
      */
     void get_bounding_box(int& global0, int& global1, int& localExt0, int& localExt1) const;
 
+    /*!
+     *  @brief Set the global coordinates of the upper left corner.
+     *
+     *  @param global Global coordinates in each dimension.
+     */
+    void set_global(const std::vector<int>& global);
+
+    /*!
+     * @brief Set the global extents in each dimension.
+     *
+     * @param globalExt Global extents in each dimension.
+     */
+    void set_globalExt(const std::vector<int>& globalExt);
+
+    /*!
+     * @brief Recompute _global_id and _local_id based on the current values of
+     *        _global, _localExt, _globalExt, and _land_mask.
+     */
+    void recompute_ids();
+
 private:
     // Construct a ditributed grid from a NetCDF file describing the global domain
     Grid(MPI_Comm comm, const std::string& filename, const std::string& dim0_id = "x",
@@ -235,6 +257,7 @@ private:
     int _num_nonzero_objects = 0; // Number of non-land grid points
     bool _px = false; // Periodicity in the x-direction
     bool _py = false; // Periodicity in the y-direction
+    bool _ignore_mask = false; // Flag indicating whether the land mask is active
     std::vector<int> _land_mask = {}; // Land mask values
     std::vector<int> _local_id = {}; // Map from sparse to dense index
     std::vector<int> _global_id = {}; // Unique non-land grid point IDs

--- a/Grid.hpp
+++ b/Grid.hpp
@@ -179,6 +179,13 @@ public:
     void get_bounding_box(int& global0, int& global1, int& localExt0, int& localExt1) const;
 
     /*!
+     * @brief Set the MPI communicator.
+     *
+     * @param comm MPI communicator.
+     */
+    void set_comm(MPI_Comm comm);
+
+    /*!
      *  @brief Set the global coordinates of the upper left corner.
      *
      *  @param global Global coordinates in each dimension.

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -668,6 +668,16 @@ void Partitioner::setGlobalExt(const std::vector<int>& globalExt)
     _globalExt = globalExt;
 }
 
+std::vector<int> Partitioner::getProcId() const
+{
+    return _procId;
+}
+
+void Partitioner::setProcId(const std::vector<int>& procId)
+{
+    _procId = procId;
+}
+
 void Partitioner::discover_neighbours()
 {
     /*

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -618,6 +618,56 @@ Partitioner* Partitioner::Factory::create(
         throw std::runtime_error("Invalid partitioner!");
 }
 
+void Partitioner::setTotalNumProcs(int totalNumProcs)
+{
+    _totalNumProcs = totalNumProcs;
+}
+
+void Partitioner::setComm(MPI_Comm comm)
+{
+    _comm = comm;
+}
+
+std::vector<int> Partitioner::getLocalExtNew() const
+{
+    return _localExtNew;
+}
+
+void Partitioner::setLocalExtNew(const std::vector<int>& localExtNew)
+{
+    _localExtNew = localExtNew;
+}
+
+std::vector<int> Partitioner::getGlobalNew() const
+{
+    return _globalNew;
+}
+
+void Partitioner::setGlobalNew(const std::vector<int>& globalNew)
+{
+    _globalNew = globalNew;
+}
+
+std::vector<int> Partitioner::getGlobal() const
+{
+    return _global;
+}
+
+void Partitioner::setGlobal(const std::vector<int>& global)
+{
+    _global = global;
+}
+
+std::vector<int> Partitioner::getGlobalExt() const
+{
+    return _globalExt;
+}
+
+void Partitioner::setGlobalExt(const std::vector<int>& globalExt)
+{
+    _globalExt = globalExt;
+}
+
 void Partitioner::discover_neighbours()
 {
     /*

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -618,65 +618,32 @@ Partitioner* Partitioner::Factory::create(
         throw std::runtime_error("Invalid partitioner!");
 }
 
-void Partitioner::setTotalNumProcs(int totalNumProcs)
-{
-    _totalNumProcs = totalNumProcs;
-}
+void Partitioner::setTotalNumProcs(int totalNumProcs) { _totalNumProcs = totalNumProcs; }
 
-void Partitioner::setComm(MPI_Comm comm)
-{
-    _comm = comm;
-}
+void Partitioner::setComm(MPI_Comm comm) { _comm = comm; }
 
-std::vector<int> Partitioner::getLocalExtNew() const
-{
-    return _localExtNew;
-}
+std::vector<int> Partitioner::getLocalExtNew() const { return _localExtNew; }
 
 void Partitioner::setLocalExtNew(const std::vector<int>& localExtNew)
 {
     _localExtNew = localExtNew;
 }
 
-std::vector<int> Partitioner::getGlobalNew() const
-{
-    return _globalNew;
-}
+std::vector<int> Partitioner::getGlobalNew() const { return _globalNew; }
 
-void Partitioner::setGlobalNew(const std::vector<int>& globalNew)
-{
-    _globalNew = globalNew;
-}
+void Partitioner::setGlobalNew(const std::vector<int>& globalNew) { _globalNew = globalNew; }
 
-std::vector<int> Partitioner::getGlobal() const
-{
-    return _global;
-}
+std::vector<int> Partitioner::getGlobal() const { return _global; }
 
-void Partitioner::setGlobal(const std::vector<int>& global)
-{
-    _global = global;
-}
+void Partitioner::setGlobal(const std::vector<int>& global) { _global = global; }
 
-std::vector<int> Partitioner::getGlobalExt() const
-{
-    return _globalExt;
-}
+std::vector<int> Partitioner::getGlobalExt() const { return _globalExt; }
 
-void Partitioner::setGlobalExt(const std::vector<int>& globalExt)
-{
-    _globalExt = globalExt;
-}
+void Partitioner::setGlobalExt(const std::vector<int>& globalExt) { _globalExt = globalExt; }
 
-std::vector<int> Partitioner::getProcId() const
-{
-    return _procId;
-}
+std::vector<int> Partitioner::getProcId() const { return _procId; }
 
-void Partitioner::setProcId(const std::vector<int>& procId)
-{
-    _procId = procId;
-}
+void Partitioner::setProcId(const std::vector<int>& procId) { _procId = procId; }
 
 void Partitioner::discover_neighbours()
 {

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -46,6 +46,16 @@ public:
     virtual void partition(Grid& grid) = 0;
 
     /*!
+     * @brief Initializes the partitioner with grid parameters.
+     *
+     * Sets the method variables (grid extents, bounding box, periodicity) from
+     * the provided grid.
+     *
+     * @param grid Reference to the grid object.
+     */
+    virtual void initialize(Grid& grid) = 0;
+
+    /*!
      * @brief Returns the new bounding box for this process after partitioning.
      *
      * @param global0 Global coordinate in the 1st dimension of the upper left

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -123,14 +123,84 @@ public:
      */
     void saveMetadata(const std::string& filename) const;
 
+    /*!
+     * @brief Sets the total number of processes.
+     *
+     * @param totalNumProcs Total number of processes in communicator.
+     */
+    void setTotalNumProcs(int totalNumProcs);
+
+    /*!
+     * @brief Sets the MPI communicator.
+     *
+     * @param comm MPI communicator.
+     */
+    void setComm(MPI_Comm comm);
+
+    /*!
+     * @brief Returns the local extents in each dimension after partitioning.
+     *
+     * @return A vector of size NDIMS containing the local extents.
+     */
+    std::vector<int> getLocalExtNew() const;
+
+    /*!
+     * @brief Sets the local extents in each dimension after partitioning.
+     *
+     * @param localExtNew A vector of size NDIMS containing the local extents.
+     */
+    void setLocalExtNew(const std::vector<int>& localExtNew);
+
+    /*!
+     * @brief Returns the global coordinates of the upper left corner after partitioning.
+     *
+     * @return A vector of size NDIMS containing the global coordinates.
+     */
+    std::vector<int> getGlobalNew() const;
+
+    /*!
+     * @brief Sets the global coordinates of the upper left corner after partitioning.
+     *
+     * @param globalNew A vector of size NDIMS containing the global coordinates.
+     */
+    void setGlobalNew(const std::vector<int>& globalNew);
+
+    /*!
+     * @brief Returns the global coordinates of the upper left corner.
+     *
+     * @return A vector of size NDIMS containing the global coordinates.
+     */
+    std::vector<int> getGlobal() const;
+
+    /*!
+     * @brief Sets the global coordinates of the upper left corner.
+     *
+     * @param global A vector of size NDIMS containing the global coordinates.
+     */
+    void setGlobal(const std::vector<int>& global);
+
+    /*!
+     * @brief Returns the global extents in each dimension.
+     *
+     * @return A vector of size NDIMS containing the global extents.
+     */
+    std::vector<int> getGlobalExt() const;
+
+    /*!
+     * @brief Sets the global extents in each dimension.
+     *
+     * @param globalExt A vector of size NDIMS containing the global extents.
+     */
+    void setGlobalExt(const std::vector<int>& globalExt);
+
+    // Discover the neighbours and halo sizes of the process after partitioning
+    void discover_neighbours();
+
 protected:
     // Construct a partitioner
     // We are using the named constructor idiom so that objects can only be
     // created in the heap to ensure it's dtor is executed before MPI_Finalize()
     Partitioner(MPI_Comm comm);
-
-    // Discover the neighbours and halo sizes of the process after partitioning
-    void discover_neighbours();
 
 protected:
     MPI_Comm _comm; // MPI communicator

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -203,6 +203,18 @@ public:
      */
     void setGlobalExt(const std::vector<int>& globalExt);
 
+    /*!     * @brief Returns the process IDs of the latest 2D domain decomposition.
+     *
+     * @return A vector containing the partition ID of each point in the grid.
+     */
+    std::vector<int> getProcId() const;
+
+    /*!     * @brief Sets the process IDs of the latest 2D domain decomposition.
+     *
+     * @param procId A vector containing the partition ID of each point in the grid.
+     */
+    void setProcId(const std::vector<int>& procId);
+
     // Discover the neighbours and halo sizes of the process after partitioning
     void discover_neighbours();
 

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -4,8 +4,8 @@
  * @date 05 Nov 2024
  */
 
-#include "ZoltanPartitioner.hpp"
 #include "Utils.hpp"
+#include "ZoltanPartitioner.hpp"
 
 #include <algorithm>
 #include <cfloat>
@@ -193,9 +193,6 @@ void ZoltanPartitioner::partition(Grid& grid)
             _localExtNew[idx] = globalExtOrig[idx] - _globalNew[idx];
         }
     }
-
-    // Find my neighbours
-    discover_neighbours();
 
     // Find the process IDs of each grid point I own
     if (grid.get_num_objects() != grid.get_num_nonzero_objects()) {

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -4,8 +4,8 @@
  * @date 05 Nov 2024
  */
 
-#include "Utils.hpp"
 #include "ZoltanPartitioner.hpp"
+#include "Utils.hpp"
 
 #include <algorithm>
 #include <cfloat>

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -90,7 +90,7 @@ ZoltanPartitioner* ZoltanPartitioner::create(MPI_Comm comm, int argc, char** arg
     return new ZoltanPartitioner(comm, argc, argv);
 }
 
-void ZoltanPartitioner::partition(Grid& grid)
+void ZoltanPartitioner::initialize(Grid& grid)
 {
     // Load initial grid state
     _numProcs = grid.getNumProcs();
@@ -98,6 +98,11 @@ void ZoltanPartitioner::partition(Grid& grid)
     grid.get_bounding_box(_global[0], _global[1], _localExt[0], _localExt[1]);
     _px = grid.get_px();
     _py = grid.get_py();
+}
+
+void ZoltanPartitioner::partition(Grid& grid)
+{
+    initialize(grid);
 
     if (_totalNumProcs == 1) {
         for (int idx = 0; idx < 2; idx++) {

--- a/ZoltanPartitioner.hpp
+++ b/ZoltanPartitioner.hpp
@@ -43,6 +43,16 @@ public:
     static ZoltanPartitioner* create(MPI_Comm comm, int argc, char** argv);
 
     /*!
+     * @brief Initializes the partitioner with grid parameters.
+     *
+     * Sets the method variables (grid extents, bounding box, periodicity) from
+     * the provided grid.
+     *
+     * @param grid Reference to the grid object.
+     */
+    void initialize(Grid& grid) override;
+
+    /*!
      * @brief Partitions a 2D grid into rectangular boxes, one per process.
      *
      * Partitions a 2D grid into rectangular boxes, one per process, taking into

--- a/main.cpp
+++ b/main.cpp
@@ -111,29 +111,46 @@ int main(int argc, char* argv[])
 
     // Create a Zoltan partitioner (on sub_comm if tripolar, otherwise on comm)
     Partitioner* partitioner
-        = Partitioner::Factory::create(sub_comm, argc, argv, PartitionerType::Zoltan_RCB);
+        = Partitioner::Factory::create(comm, argc, argv, PartitionerType::Zoltan_RCB);
+
+    Partitioner* subpartitioner;
 
     // Partition grid
     if (tripolar) {
         // Create a copy of the grid on each rank
         // overwrite global position and extents for subgrids
+        subpartitioner
+            = Partitioner::Factory::create(sub_comm, argc, argv, PartitionerType::Zoltan_RCB);
         subgrid->set_global({ 0, g1 });
         auto globalExt = grid->getGlobalExt();
         subgrid->set_globalExt({ globalExt[0] / 2, globalExt[1] });
+        subgrid->set_comm(sub_comm);
         subgrid->recompute_ids();
-        partitioner->partition(*subgrid);
+        subpartitioner->partition(*subgrid);
     } else {
         partitioner->partition(*grid);
-    }
-
-    // Free the sub-communicator
-    if (tripolar) {
-        MPI_Comm_free(&sub_comm);
     }
 
     // Store partitioning results in netCDF file
     int numProcs;
     MPI_Comm_size(comm, &numProcs);
+
+    if (tripolar) {
+        auto globalExt = subpartitioner->getGlobalNew();
+        partitioner->setGlobalNew({ globalExt[0] + g0, globalExt[1] });
+        auto localExt = subpartitioner->getLocalExtNew();
+        partitioner->setLocalExtNew(localExt);
+        partitioner->setTotalNumProcs(numProcs);
+        partitioner->setGlobalExt(grid->getGlobalExt());
+    }
+
+    // Find my neighbours
+    partitioner->discover_neighbours();
+
+    // Free the sub-communicator
+    if (tripolar) {
+        MPI_Comm_free(&sub_comm);
+    }
 
     // TODO: gather _procId results across both halves onto MPI_COMM_WORLD and
     // re-run neighbour discovery. Until then, saveMask/saveMetadata use the
@@ -143,9 +160,7 @@ int main(int argc, char* argv[])
         partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
         partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
     } else {
-        std::cerr << "WARNING: tripolar mode active — saving skipped (known limitation, "
-                     "partitioner _comm is freed)"
-                  << std::endl;
+        partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
     }
 
     // Cleanup

--- a/main.cpp
+++ b/main.cpp
@@ -54,7 +54,9 @@ int main(int argc, char* argv[])
         ("ignore-mask,i", po::bool_switch()->default_value(false), "Ignore mask in netCDF grid file")
         ("periodic-x,px", po::bool_switch()->default_value(false), "Periodicity in x-direction")
         ("periodic-y,py", po::bool_switch()->default_value(false), "Periodicity in y-direction")
-        ("output-prefix,op", po::value<string>()->default_value(""), "Prefix for output filenames");
+        ("output-prefix,op", po::value<string>()->default_value(""), "Prefix for output filenames")
+        ("tripolar,t", po::bool_switch()->default_value(false),
+            "Use split-communicator tri-polar decomposition");
     // clang-format on
 
     // Parse optional command line options
@@ -83,23 +85,54 @@ int main(int argc, char* argv[])
         prefix += "_";
     }
 
+    // Capture tripolar flag
+    bool tripolar = vm["tripolar"].as<bool>();
+
     // Build grid from netCDF file
     Grid* grid = Grid::create(comm, vm["grid"].as<string>(), vm["xdim"].as<string>(),
         vm["ydim"].as<string>(), order, vm["mask"].as<string>(), vm["ignore-mask"].as<bool>(),
         vm["periodic-x"].as<bool>(), vm["periodic-y"].as<bool>());
 
-    // Create a Zoltan partitioner
+    // Split communicator into two sub-communicators by X-coordinate (East/West)
+    int g0, g1, le0, le1;
+    grid->get_bounding_box(g0, g1, le0, le1);
+
+    MPI_Comm sub_comm = comm; // default: no split
+    if (tripolar) {
+        int xMid = grid->getGlobalExt()[0] / 2; // X midpoint for East/West split
+        int color = (g0 < xMid) ? 0 : 1; // 0 = West, 1 = East
+        int world_rank;
+        MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+        MPI_Comm_split(MPI_COMM_WORLD, color, world_rank, &sub_comm);
+    }
+
+    // Create a Zoltan partitioner (on sub_comm if tripolar, otherwise on comm)
     Partitioner* partitioner
-        = Partitioner::Factory::create(comm, argc, argv, PartitionerType::Zoltan_RCB);
+        = Partitioner::Factory::create(sub_comm, argc, argv, PartitionerType::Zoltan_RCB);
 
     // Partition grid
     partitioner->partition(*grid);
 
+    // Free the sub-communicator
+    if (tripolar) {
+        MPI_Comm_free(&sub_comm);
+    }
+
     // Store partitioning results in netCDF file
     int numProcs;
     MPI_Comm_size(comm, &numProcs);
-    partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
-    partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
+
+    // TODO: gather _procId results across both halves onto MPI_COMM_WORLD and
+    // re-run neighbour discovery. Until then, saveMask/saveMetadata use the
+    // partitioner's _comm which is the (now-freed) sub_comm in tripolar mode.
+    // For now we skip saving in tripolar mode to avoid using a freed communicator.
+    if (!tripolar) {
+        partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
+        partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
+    } else {
+        std::cerr << "WARNING: tripolar mode active — saving skipped (known limitation, "
+                     "partitioner _comm is freed)" << std::endl;
+    }
 
     // Cleanup
     delete grid;

--- a/main.cpp
+++ b/main.cpp
@@ -93,6 +93,9 @@ int main(int argc, char* argv[])
         vm["ydim"].as<string>(), order, vm["mask"].as<string>(), vm["ignore-mask"].as<bool>(),
         vm["periodic-x"].as<bool>(), vm["periodic-y"].as<bool>());
 
+    // only used for tripolar case
+    Grid* subgrid = new Grid(*grid);
+
     // Split communicator into two sub-communicators by X-coordinate (East/West)
     int g0, g1, le0, le1;
     grid->get_bounding_box(g0, g1, le0, le1);
@@ -111,7 +114,17 @@ int main(int argc, char* argv[])
         = Partitioner::Factory::create(sub_comm, argc, argv, PartitionerType::Zoltan_RCB);
 
     // Partition grid
-    partitioner->partition(*grid);
+    if (tripolar) {
+        // Create a copy of the grid on each rank
+        // overwrite global position and extents for subgrids
+        subgrid->set_global({ 0, g1 });
+        auto globalExt = grid->getGlobalExt();
+        subgrid->set_globalExt({ globalExt[0] / 2, globalExt[1] });
+        subgrid->recompute_ids();
+        partitioner->partition(*subgrid);
+    } else {
+        partitioner->partition(*grid);
+    }
 
     // Free the sub-communicator
     if (tripolar) {
@@ -131,11 +144,13 @@ int main(int argc, char* argv[])
         partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
     } else {
         std::cerr << "WARNING: tripolar mode active — saving skipped (known limitation, "
-                     "partitioner _comm is freed)" << std::endl;
+                     "partitioner _comm is freed)"
+                  << std::endl;
     }
 
     // Cleanup
     delete grid;
+    delete subgrid;
     delete partitioner;
 
     // Finalize MPI

--- a/main.cpp
+++ b/main.cpp
@@ -101,9 +101,10 @@ int main(int argc, char* argv[])
     grid->get_bounding_box(g0, g1, le0, le1);
 
     MPI_Comm sub_comm = comm; // default: no split
+    int color = 0;
     if (tripolar) {
         int xMid = grid->getGlobalExt()[0] / 2; // X midpoint for East/West split
-        int color = (g0 < xMid) ? 0 : 1; // 0 = West, 1 = East
+        color = (g0 < xMid) ? 0 : 1; // 0 = West, 1 = East
         int world_rank;
         MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
         MPI_Comm_split(MPI_COMM_WORLD, color, world_rank, &sub_comm);
@@ -136,12 +137,11 @@ int main(int argc, char* argv[])
     MPI_Comm_size(comm, &numProcs);
 
     if (tripolar) {
+        partitioner->initialize(*grid);
         auto globalExt = subpartitioner->getGlobalNew();
         partitioner->setGlobalNew({ globalExt[0] + g0, globalExt[1] });
         auto localExt = subpartitioner->getLocalExtNew();
         partitioner->setLocalExtNew(localExt);
-        partitioner->setTotalNumProcs(numProcs);
-        partitioner->setGlobalExt(grid->getGlobalExt());
     }
 
     // Find my neighbours
@@ -152,14 +152,21 @@ int main(int argc, char* argv[])
         MPI_Comm_free(&sub_comm);
     }
 
-    // TODO: gather _procId results across both halves onto MPI_COMM_WORLD and
-    // re-run neighbour discovery. Until then, saveMask/saveMetadata use the
-    // partitioner's _comm which is the (now-freed) sub_comm in tripolar mode.
-    // For now we skip saving in tripolar mode to avoid using a freed communicator.
-    if (!tripolar) {
+    if (tripolar) {
+        auto procId = subpartitioner->getProcId();
+        if (color == 1) {
+            int offset = numProcs / 2;
+            for (auto& v : procId) {
+                if (v > -1) {
+                    v += offset;
+                }
+            }
+        }
+        partitioner->setProcId(procId);
         partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
         partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
     } else {
+        partitioner->saveMask(prefix + "partition_mask_" + to_string(numProcs) + ".nc");
         partitioner->saveMetadata(prefix + "partition_metadata_" + to_string(numProcs) + ".nc");
     }
 


### PR DESCRIPTION
**WIP Do Not Merge**

# Two-stage tripolar domain decomposition using split MPI communicators

fixes #85 

## Summary
Implement two-stage tripolar domain decomposition: when the `--tripolar` flag is passed, the domain is split East/West by coordinate via `MPI_Comm_split`, each half is partitioned independently with Zoltan, and results are merged back into a single global partitioning. The base `partition()` flow is preserved for non-tripolar runs.

## Changes

### `main.cpp`
- Add `--tripolar` (`-t`) CLI flag to enable split-communicator mode
- Split `MPI_COMM_WORLD` into East/West sub-communicators using `MPI_Comm_split` (color = 0 West, 1 East, midpoint = `globalExt[0] / 2`)
- Create a copy of the grid (`subgrid`) for sub-communicator work
- Run partitioning on `subgrid` + `subpartitioner` within each sub-communicator, or fall through to standard single-communicator path
- Merge sub-partitioner results back into the original `partitioner`: copy `GlobalNew`, `LocalExtNew`, and adjust `ProcId` offsets for the East half
- Call `discover_neighbours()` after merge to rebuild neighbour info on the unified communicator
- Clean up sub-communicator and `subgrid` resources

### `Grid.cpp` / `Grid.hpp`
- Replace deleted copy constructor with an explicit `Grid(const Grid& other)` copy ctor (needed for subgrid creation)
- Add `set_comm()`, `set_global()`, `set_globalExt()` setters to allow reconfiguring a grid copy for sub-communicator use
- Add `recompute_ids()` to regenerate `_global_id` / `_local_id` after the grid's bounding box changes (East/West halves get different global positions)
- Add `_ignore_mask` member (defaults `false`) to control whether the land mask is applied during id recomputation

### `Partitioner.cpp` / `Partitioner.hpp`
- Move `discover_neighbours()` from protected to public
- Add `initialize(Grid&)` virtual method to base `Partitioner` — extracts grid extents/bounding-box/periodicity into partitioner member variables, separating setup from partitioning
- Add a large set of getter/setter accessors: `setTotalNumProcs`, `setComm`, `get/setLocalExtNew`, `get/setGlobalNew`, `get/setGlobal`, `get/setGlobalExt`, `get/setProcId`

### `ZoltanPartitioner.cpp` / `ZoltanPartitioner.hpp`
- Implement `initialize(Grid&)` by copying the grid setup logic previously inside `partition()`
- Have `partition(Grid&)` call `initialize(grid)` first, preserving all original partitioning logic
- Remove duplicate `discover_neighbours()` call from inside `partition()` (now called once after merge in `main`)
