### PR TITLE
Fix single proc runs (e.g., mpirun -n 1)

### DIFF
--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -117,6 +117,8 @@ void ZoltanPartitioner::partition(Grid& grid)
             _procId.resize(grid.get_num_objects(), _rank);
         }
 
+        discover_neighbours();
+
         return;
     }
 

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -44,6 +44,18 @@ for TEST in test_1 test_2 test_1_px test_1_py test_1_px_py; do
   echo -e "\033[0;32mTest passed\033[0m"
 done
 
+for TEST in test_1_px_py; do
+  echo "Running integration test '${TEST}' (1 process)"
+  ${MPIEXEC} --oversubscribe ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS} \
+    ../decomp -g ${FNAMES[${TEST}]} ${FLAGS[${TEST}]} >/dev/null
+
+  for filename in partition_mask_1 partition_metadata_1; do
+    ncdump "${filename}.nc" >"${filename}.cdl"
+    diff "${filename}.cdl" "${CMAKE_CURRENT_SOURCE_DIR}/${TEST}/ref_${filename}.cdl"
+  done
+  echo -e "\033[0;32mTest passed\033[0m"
+done
+
 for TEST in test_3 test_4 test_4_px test_4_py test_4_px_py; do
   echo "Running integration corner test '${TEST}'"
   ${MPIEXEC} --oversubscribe ${MPIEXEC_NUMPROC_FLAG} 4 ${MPIEXEC_PREFLAGS} \

--- a/test/test_1_px_py/ref_partition_mask_1.cdl
+++ b/test/test_1_px_py/ref_partition_mask_1.cdl
@@ -1,0 +1,17 @@
+netcdf partition_mask_1 {
+dimensions:
+	y = 4 ;
+	x = 6 ;
+variables:
+	int pid(y, x) ;
+
+// global attributes:
+		:num_processes = 1 ;
+data:
+
+ pid =
+  0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0 ;
+}

--- a/test/test_1_px_py/ref_partition_metadata_1.cdl
+++ b/test/test_1_px_py/ref_partition_metadata_1.cdl
@@ -1,0 +1,188 @@
+netcdf partition_metadata_1 {
+dimensions:
+	NX = 6 ;
+	NY = 4 ;
+	P = 1 ;
+	L = UNLIMITED ; // (0 currently)
+	R = UNLIMITED ; // (0 currently)
+	B = UNLIMITED ; // (0 currently)
+	T = UNLIMITED ; // (0 currently)
+	TL = UNLIMITED ; // (0 currently)
+	TR = UNLIMITED ; // (0 currently)
+	BR = UNLIMITED ; // (0 currently)
+	BL = UNLIMITED ; // (0 currently)
+	L_periodic = 1 ;
+	R_periodic = 1 ;
+	B_periodic = 1 ;
+	T_periodic = 1 ;
+	TL_periodic = 1 ;
+	TR_periodic = 1 ;
+	BR_periodic = 1 ;
+	BL_periodic = 1 ;
+
+group: bounding_boxes {
+  variables:
+  	int domain_x(P) ;
+  	int domain_extent_x(P) ;
+  	int domain_y(P) ;
+  	int domain_extent_y(P) ;
+  data:
+
+   domain_x = 0 ;
+
+   domain_extent_x = 6 ;
+
+   domain_y = 0 ;
+
+   domain_extent_y = 4 ;
+  } // group bounding_boxes
+
+group: connectivity {
+  variables:
+  	int left_neighbours(P) ;
+  	int left_neighbour_ids(L) ;
+  	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
+  	int right_neighbours(P) ;
+  	int right_neighbour_ids(R) ;
+  	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
+  	int bottom_neighbours(P) ;
+  	int bottom_neighbour_ids(B) ;
+  	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
+  	int top_neighbours(P) ;
+  	int top_neighbour_ids(T) ;
+  	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
+  	int top_left_neighbours(P) ;
+  	int top_left_neighbour_ids(TL) ;
+  	int top_left_neighbour_send(TL) ;
+  	int top_right_neighbours(P) ;
+  	int top_right_neighbour_ids(TR) ;
+  	int top_right_neighbour_send(TR) ;
+  	int bottom_right_neighbours(P) ;
+  	int bottom_right_neighbour_ids(BR) ;
+  	int bottom_right_neighbour_send(BR) ;
+  	int bottom_left_neighbours(P) ;
+  	int bottom_left_neighbour_ids(BL) ;
+  	int bottom_left_neighbour_send(BL) ;
+  	int left_neighbours_periodic(P) ;
+  	int left_neighbour_ids_periodic(L_periodic) ;
+  	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
+  	int right_neighbours_periodic(P) ;
+  	int right_neighbour_ids_periodic(R_periodic) ;
+  	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
+  	int bottom_neighbours_periodic(P) ;
+  	int bottom_neighbour_ids_periodic(B_periodic) ;
+  	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
+  	int top_neighbours_periodic(P) ;
+  	int top_neighbour_ids_periodic(T_periodic) ;
+  	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
+  	int top_left_neighbours_periodic(P) ;
+  	int top_left_neighbour_ids_periodic(TL_periodic) ;
+  	int top_left_neighbour_send_periodic(TL_periodic) ;
+  	int top_right_neighbours_periodic(P) ;
+  	int top_right_neighbour_ids_periodic(TR_periodic) ;
+  	int top_right_neighbour_send_periodic(TR_periodic) ;
+  	int bottom_right_neighbours_periodic(P) ;
+  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
+  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
+  	int bottom_left_neighbours_periodic(P) ;
+  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
+  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
+  data:
+
+   left_neighbours = 0 ;
+
+   right_neighbours = 0 ;
+
+   bottom_neighbours = 0 ;
+
+   top_neighbours = 0 ;
+
+   top_left_neighbours = 0 ;
+
+   top_right_neighbours = 0 ;
+
+   bottom_right_neighbours = 0 ;
+
+   bottom_left_neighbours = 0 ;
+
+   left_neighbours_periodic = 1 ;
+
+   left_neighbour_ids_periodic = 0 ;
+
+   left_neighbour_halos_periodic = 4 ;
+
+   left_neighbour_halo_send_periodic = 6 ;
+
+   left_neighbour_halo_recv_periodic = 16 ;
+
+   right_neighbours_periodic = 1 ;
+
+   right_neighbour_ids_periodic = 0 ;
+
+   right_neighbour_halos_periodic = 4 ;
+
+   right_neighbour_halo_send_periodic = 16 ;
+
+   right_neighbour_halo_recv_periodic = 6 ;
+
+   bottom_neighbours_periodic = 1 ;
+
+   bottom_neighbour_ids_periodic = 0 ;
+
+   bottom_neighbour_halos_periodic = 6 ;
+
+   bottom_neighbour_halo_send_periodic = 10 ;
+
+   bottom_neighbour_halo_recv_periodic = 0 ;
+
+   top_neighbours_periodic = 1 ;
+
+   top_neighbour_ids_periodic = 0 ;
+
+   top_neighbour_halos_periodic = 6 ;
+
+   top_neighbour_halo_send_periodic = 0 ;
+
+   top_neighbour_halo_recv_periodic = 10 ;
+
+   top_left_neighbours_periodic = 1 ;
+
+   top_left_neighbour_ids_periodic = 0 ;
+
+   top_left_neighbour_send_periodic = 6 ;
+
+   top_right_neighbours_periodic = 1 ;
+
+   top_right_neighbour_ids_periodic = 0 ;
+
+   top_right_neighbour_send_periodic = 16 ;
+
+   bottom_right_neighbours_periodic = 1 ;
+
+   bottom_right_neighbour_ids_periodic = 0 ;
+
+   bottom_right_neighbour_send_periodic = 19 ;
+
+   bottom_left_neighbours_periodic = 1 ;
+
+   bottom_left_neighbour_ids_periodic = 0 ;
+
+   bottom_left_neighbour_send_periodic = 9 ;
+  } // group connectivity
+}


### PR DESCRIPTION
@Mikolaj-A-Kowalski identified that the single process runs `mpirun -n 1` were not producing the correct metadata.

E.g., the parition metadata would show no periodic neighbours.

```
netcdf partition_metadata_1 {
dimensions:
	NX = 6 ;
	NY = 4 ;
	P = 1 ;
	L = UNLIMITED ; // (0 currently)
	R = UNLIMITED ; // (0 currently)
	B = UNLIMITED ; // (0 currently)
	T = UNLIMITED ; // (0 currently)
	TL = UNLIMITED ; // (0 currently)
	TR = UNLIMITED ; // (0 currently)
	BR = UNLIMITED ; // (0 currently)
	BL = UNLIMITED ; // (0 currently)
	L_periodic = UNLIMITED ; // (0 currently)
	R_periodic = UNLIMITED ; // (0 currently)
	B_periodic = UNLIMITED ; // (0 currently)
	T_periodic = UNLIMITED ; // (0 currently)
	TL_periodic = UNLIMITED ; // (0 currently)
	TR_periodic = UNLIMITED ; // (0 currently)
	BR_periodic = UNLIMITED ; // (0 currently)
	BL_periodic = UNLIMITED ; // (0 currently)
``` 

`ZoltanPartitioner::partition` had an early return when run with 1 proc only. This PR fixes that by calling `discover_neighbours();` before returning. This means that the necessary metadata is calculated for the domain before we call `partitioner->saveMask` and `partitioner->saveMetadata`.

E.g.,

```
netcdf partition_metadata_1 {
dimensions:
	NX = 6 ;
	NY = 4 ;
	P = 1 ;
	L = UNLIMITED ; // (0 currently)
	R = UNLIMITED ; // (0 currently)
	B = UNLIMITED ; // (0 currently)
	T = UNLIMITED ; // (0 currently)
	TL = UNLIMITED ; // (0 currently)
	TR = UNLIMITED ; // (0 currently)
	BR = UNLIMITED ; // (0 currently)
	BL = UNLIMITED ; // (0 currently)
	L_periodic = 1 ;
	R_periodic = 1 ;
	B_periodic = 1 ;
	T_periodic = 1 ;
	TL_periodic = 1 ;
	TR_periodic = 1 ;
	BR_periodic = 1 ;
	BL_periodic = 1 ;
``` 

I have also added an integration test for a single proc run, so we can check it doesn't regress in the future.