### PR TITLE
Add unit tests infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if(BUILD_TESTS)
   include(CTest)
   enable_testing()
   add_subdirectory(test)
+  add_subdirectory(unit_test)
 endif()
 
 # Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 set(PROJECT_NAME nextSIMutils)
 set(LIB_NAME domain_decomp)
 set(EXEC_NAME decomp)
+set(INTERNAL_CORE_NAME decomp_core)
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
 project(${PROJECT_NAME} VERSION ${VERSION_MAJOR}.${VERSION_MINOR} LANGUAGES CXX)
@@ -113,12 +114,28 @@ install(EXPORT ${PROJECT_NAME}
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
   )
 
-# Executable
-add_executable(${EXEC_NAME}
-  ${PROJECT_SOURCE_DIR}/DomainUtils.cpp
+# We want to reuse the same compiled files in multiple targets,
+# e.g. executable, library  and test executables
+# we compile them once to a static internal library and link against it.
+add_library(${INTERNAL_CORE_NAME} STATIC
   ${PROJECT_SOURCE_DIR}/Grid.cpp
+  ${PROJECT_SOURCE_DIR}/DomainUtils.cpp
   ${PROJECT_SOURCE_DIR}/Partitioner.cpp
   ${PROJECT_SOURCE_DIR}/ZoltanPartitioner.cpp
+)
+
+target_include_directories(${INTERNAL_CORE_NAME}
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+  PRIVATE ${netCDF_INCLUDE_DIR} ${Zoltan_INCLUDE_DIRS}
+)
+
+target_link_libraries(${INTERNAL_CORE_NAME}
+  PUBLIC MPI::MPI_CXX
+  PRIVATE netcdf ${Zoltan_LIBRARIES}
+)
+
+# Executable
+add_executable(${EXEC_NAME}
   ${PROJECT_SOURCE_DIR}/main.cpp)
 # Create an alias to be used within the project and by other projects
 add_executable(${PROJECT_NAME}::${EXEC_NAME} ALIAS ${EXEC_NAME})
@@ -127,8 +144,7 @@ target_include_directories(${EXEC_NAME}
   PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${netCDF_INCLUDE_DIR} ${Zoltan_INCLUDE_DIRS}
   )
 target_link_libraries(${EXEC_NAME}
-  PUBLIC MPI::MPI_CXX
-  PRIVATE netcdf ${Zoltan_LIBRARIES} Boost::program_options
+  PRIVATE ${INTERNAL_CORE_NAME} Boost::program_options
   )
 target_link_directories(${EXEC_NAME}
   PRIVATE ${netCDF_LIB_DIR}

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 
 add_executable(unit_tests main.cpp)
-target_link_libraries(
-  unit_tests
-  PRIVATE doctest::doctest ${PROJECT_NAME}::${LIB_NAME})
+target_link_libraries(unit_tests PRIVATE doctest::doctest ${INTERNAL_CORE_NAME})
 target_include_directories(
   unit_tests
   PRIVATE ${CMAKE_SOURCE_DIR} ${DOCTEST_INCLUDE_DIR})

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+add_executable(unit_tests main.cpp)
+target_link_libraries(
+  unit_tests
+  PRIVATE doctest::doctest ${PROJECT_NAME}::${LIB_NAME})
+target_include_directories(
+  unit_tests
+  PRIVATE ${CMAKE_SOURCE_DIR} ${DOCTEST_INCLUDE_DIR})
+
+add_test(NAME unit_tests COMMAND unit_tests)

--- a/unit_test/main.cpp
+++ b/unit_test/main.cpp
@@ -6,3 +6,14 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
+
+#include "DomainUtils.hpp"
+
+
+TEST_CASE("Use symbol"){
+    // Placeholder test to verify symbol visibility when compiling tests
+    Domain d{{0,1}, {2,3}};
+
+    CHECK(d.getWidth() == 2);
+    CHECK(d.getHeight() == 2);
+}

--- a/unit_test/main.cpp
+++ b/unit_test/main.cpp
@@ -1,0 +1,8 @@
+/*!
+ * @file main.cpp
+ *
+ * Test driver for the lightweight unit tests 
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"


### PR DESCRIPTION
Adds a skeleton (for now basically empty) to enable unit testing. 

Developing the tripolar functionality I have found myself in want of being able to test the components of the algorithm (utility functions basically). The existing /integration/regression test suite is not really fit for that purpose. 

Since the `test` folder is busy as it is I though it will be cleaner to put unit tests in a separate directory.

Naturally things refuse to be easy and there is a complication related to how we compile the project. 

We cannot link the `unit_tests` executable against the shared library target because most of the functions that we wish to test are not part of the library's public API and hence are compiled with "hidden" visibility. As the result, if we try to use them in tests, this results in linking errors (symbols not being found due to visibility). 

The solution at the moment is to introduce a 2nd, static library, which we can use to collect all sources, include directories and dependencies and feed them when compiling executables (`decomp` tool and `unit_tests` for the moment). 

### To discuss in review

- Removing the dummy test before merging? I have put it there only to verify that symbols from the library are accessible.
- Trying to avoid recompiling the sources twice (once for SHARED and STATIC libraries). I am not sure it will be easy. Furthermore it may not be really what we want. We do compile executables with position independent code `-fPIC` at the moment, but it is not something we need to do)
      
