### PR TITLE
Simple support for tripolar grid topology

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ if(BUILD_TESTS)
   include(CTest)
   enable_testing()
   add_subdirectory(test)
+  add_subdirectory(unit_test)
 endif()
 
 # Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
 set(PROJECT_NAME nextSIMutils)
 set(LIB_NAME domain_decomp)
 set(EXEC_NAME decomp)
+set(INTERNAL_CORE_NAME decomp_core)
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 0)
 project(${PROJECT_NAME} VERSION ${VERSION_MAJOR}.${VERSION_MINOR} LANGUAGES CXX)
@@ -113,12 +114,28 @@ install(EXPORT ${PROJECT_NAME}
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake
   )
 
-# Executable
-add_executable(${EXEC_NAME}
-  ${PROJECT_SOURCE_DIR}/DomainUtils.cpp
+# We want to reuse the same compiled files in multiple targets,
+# e.g. executable, library  and test executables
+# we compile them once to a static internal library and link against it.
+add_library(${INTERNAL_CORE_NAME} STATIC
   ${PROJECT_SOURCE_DIR}/Grid.cpp
+  ${PROJECT_SOURCE_DIR}/DomainUtils.cpp
   ${PROJECT_SOURCE_DIR}/Partitioner.cpp
   ${PROJECT_SOURCE_DIR}/ZoltanPartitioner.cpp
+)
+
+target_include_directories(${INTERNAL_CORE_NAME}
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR}
+  PRIVATE ${netCDF_INCLUDE_DIR} ${Zoltan_INCLUDE_DIRS}
+)
+
+target_link_libraries(${INTERNAL_CORE_NAME}
+  PUBLIC MPI::MPI_CXX
+  PRIVATE netcdf ${Zoltan_LIBRARIES}
+)
+
+# Executable
+add_executable(${EXEC_NAME}
   ${PROJECT_SOURCE_DIR}/main.cpp)
 # Create an alias to be used within the project and by other projects
 add_executable(${PROJECT_NAME}::${EXEC_NAME} ALIAS ${EXEC_NAME})
@@ -127,8 +144,7 @@ target_include_directories(${EXEC_NAME}
   PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${netCDF_INCLUDE_DIR} ${Zoltan_INCLUDE_DIRS}
   )
 target_link_libraries(${EXEC_NAME}
-  PUBLIC MPI::MPI_CXX
-  PRIVATE netcdf ${Zoltan_LIBRARIES} Boost::program_options
+  PRIVATE ${INTERNAL_CORE_NAME} Boost::program_options
   )
 target_link_directories(${EXEC_NAME}
   PRIVATE ${netCDF_LIB_DIR}

--- a/DomainUtils.cpp
+++ b/DomainUtils.cpp
@@ -8,6 +8,7 @@
 #include "DomainUtils.hpp"
 #include <algorithm>
 #include <iostream>
+#include <tuple>
 
 int Domain::getWidth() const { return p2.x - p1.x; }
 int Domain::getHeight() const { return p2.y - p1.y; }
@@ -41,7 +42,48 @@ Domain Domain::fromTwoPoints(const Point& p1, const Point& p2)
 
 Domain pointReflection(Point c, Domain d)
 {
+    if (d.isEmpty()) {
+        return d;
+    }
+
     const auto p1_reflected = 2 * c - d.p1;
     const auto p2_reflected = 2 * c - d.p2;
     return Domain::fromTwoPoints(p1_reflected, p2_reflected);
+}
+
+namespace {
+
+/**
+ * @brief Compute the intersection of two 1D intervals
+ *
+ * Note that the interval is represented as [start, end]:
+ *   * start < end is a valid line segment
+ *   * start == end is a valid point
+ *   * start > end is an empty interval
+ *
+ * @param a First interval
+ * @param b Second interval
+ * @return The intersection of the two intervals.
+ */
+std::pair<int, int> intervalIntersection(const std::pair<int, int>& a, const std::pair<int, int>& b)
+{
+    const int start = std::max(a.first, b.first);
+    const int end = std::min(a.second, b.second);
+    return { start, end };
+}
+}
+
+Domain intersection(Domain d1, Domain d2)
+{
+    // Intersection in x-axis
+    // Make a structured binding in C++17
+    int x_start, x_end;
+    std::tie(x_start, x_end) = intervalIntersection({ d1.p1.x, d1.p2.x }, { d2.p1.x, d2.p2.x });
+
+    // Intersection in y-axis
+    // Make a structured binding in C++17
+    int y_start, y_end;
+    std::tie(y_start, y_end) = intervalIntersection({ d1.p1.y, d1.p2.y }, { d2.p1.y, d2.p2.y });
+
+    return { Point { x_start, y_start }, Point { x_end, y_end } };
 }

--- a/DomainUtils.cpp
+++ b/DomainUtils.cpp
@@ -25,3 +25,23 @@ int domainOverlap(const Domain d1, const Domain d2, const Edge edge)
     }
     return overlap;
 }
+
+Domain Domain::fromTwoPoints(const Point& p1, const Point& p2)
+{
+    Domain d;
+    // Lower left corner
+    d.p1.x = std::min(p1.x, p2.x);
+    d.p1.y = std::min(p1.y, p2.y);
+
+    // Upper right corner
+    d.p2.x = std::max(p1.x, p2.x);
+    d.p2.y = std::max(p1.y, p2.y);
+    return d;
+}
+
+Domain pointReflection(Point c, Domain d)
+{
+    const auto p1_reflected = 2 * c - d.p1;
+    const auto p2_reflected = 2 * c - d.p2;
+    return Domain::fromTwoPoints(p1_reflected, p2_reflected);
+}

--- a/DomainUtils.hpp
+++ b/DomainUtils.hpp
@@ -23,7 +23,14 @@ static constexpr std::array<Corner, N_CORNER> corners
 struct Point {
 
     int x, y;
+
+    // Define arithmetic on Points
+    Point operator+(const Point& other) const { return { x + other.x, y + other.y }; }
+    Point operator-(const Point& other) const { return { x - other.x, y - other.y }; }
+    Point operator*(const int scalar) const { return { x * scalar, y * scalar }; }
+    Point operator-() const { return { -x, -y }; }
 };
+inline Point operator*(const int scalar, const Point& p) { return p * scalar; }
 
 /*!
  * @brief After grid decomposition, we are left with 2D domains.
@@ -47,6 +54,24 @@ struct Domain {
      * @brief return height of domain
      */
     int getHeight() const;
+
+    /**
+     * @brief Create a domain from two points
+     *
+     * Unlike the constructor, the points do not need to be in particular order.
+     * i.e p1.y > p2.y is OK.
+     *
+     * Two points uniquely define a patch, the function will return a 'normalised'
+     * representation of the domain where the invariant:
+     *  `p1.x <= p2.x and p1.y <= p2.y` holds
+     *
+     * Degenerate domains (Lines and points) are allowed
+     *
+     * @param p1 First point
+     * @param p2 Second point
+     * @return Domain defined by the two points
+     */
+    static Domain fromTwoPoints(const Point& p1, const Point& p2);
 };
 
 /*!
@@ -60,5 +85,14 @@ struct Domain {
  * @param dir direction to find overlap ('x' or 'y')
  */
 int domainOverlap(const Domain d1, const Domain d2, const Edge edge);
+
+/*!
+ * @brief Applies point symmetry to a domain
+ *
+ * @param p Point of the symmetry
+ * @param d Domain to be reflected
+ * @return Domain reflected about point p
+ */
+Domain pointReflection(Point p, Domain d);
 
 #endif /* DOMAINUTILS_HPP */

--- a/DomainUtils.hpp
+++ b/DomainUtils.hpp
@@ -29,6 +29,10 @@ struct Point {
     Point operator-(const Point& other) const { return { x - other.x, y - other.y }; }
     Point operator*(const int scalar) const { return { x * scalar, y * scalar }; }
     Point operator-() const { return { -x, -y }; }
+
+    // Implement equality
+    bool operator==(const Point& other) const { return x == other.x && y == other.y; }
+    bool operator!=(const Point& other) const { return !(*this == other); }
 };
 inline Point operator*(const int scalar, const Point& p) { return p * scalar; }
 

--- a/DomainUtils.hpp
+++ b/DomainUtils.hpp
@@ -76,6 +76,31 @@ struct Domain {
      * @return Domain defined by the two points
      */
     static Domain fromTwoPoints(const Point& p1, const Point& p2);
+
+    /**
+     * @brief Non-normalised domain represents an empty domain (empty set)
+     */
+    bool isEmpty() const { return p1.x > p2.x || p1.y > p2.y; }
+
+    /**
+     *  @brief We support degenerate domains that collapse to a point
+     */
+    bool isPoint() const { return p1.x == p2.x && p1.y == p2.y; }
+
+    /**
+     * @brief We support degenerate domains that collapse to a line
+     */
+    bool isLine() const
+    {
+        const bool isVerticalLine = p1.x == p2.x && p1.y != p2.y;
+        const bool isHorizontalLine = p1.x != p2.x && p1.y == p2.y;
+
+        return isVerticalLine || isHorizontalLine;
+    }
+    /**
+     * @brief For completeness we check is a domain represents an area (patch)
+     */
+    bool isArea() const { return !isEmpty() && !isPoint() && !isLine(); }
 };
 
 /*!
@@ -93,10 +118,38 @@ int domainOverlap(const Domain d1, const Domain d2, const Edge edge);
 /*!
  * @brief Applies point symmetry to a domain
  *
+ * For a degenerate domain, returns a degenerate domain.
+ * Makes no guarantees about the points inside.
+ * Reflection of an empty set is an empty set is our logic here.
+ *
  * @param p Point of the symmetry
  * @param d Domain to be reflected
  * @return Domain reflected about point p
  */
 Domain pointReflection(Point p, Domain d);
+
+/*!
+ *
+ * @brief Domain intersection
+ *
+ * Takes two domains and returns the intersection of the two.
+ * The domains include their boundaries, so two domains that share
+ * a section of an edge or a point will return a degenerate "line"
+ * or "point" domain.
+ *
+ * The intersection of disjoint domains returns a degenerate domain that
+ * represents an empty set.
+ *
+ * The intention is to use this function to compute neighbourhood relation
+ * between the domains.
+ *
+ * The operation should be commutative and associative, but we don't test
+ * this property at the moment (albeit we have a bug if it not holds).
+ *
+ * @param d1 First domain
+ * @param d2 Second domain
+ *
+ */
+Domain intersection(Domain d1, Domain d2);
 
 #endif /* DOMAINUTILS_HPP */

--- a/Grid.cpp
+++ b/Grid.cpp
@@ -34,18 +34,19 @@ static std::vector<int> find_factors(const int n)
     }
 }
 
-Grid* Grid::create(MPI_Comm comm, const std::string& filename, bool ignore_mask, bool px, bool py)
+Grid* Grid::create(
+    MPI_Comm comm, const std::string& filename, bool ignore_mask, bool px, bool py, bool tripolar)
 {
-    return new Grid(
-        comm, filename, "x", "y", std::vector<int>({ 1, 0 }), "mask", ignore_mask, px, py);
+    return new Grid(comm, filename, "x", "y", std::vector<int>({ 1, 0 }), "mask", ignore_mask, px,
+        py, tripolar);
 }
 
 Grid* Grid::create(MPI_Comm comm, const std::string& filename, const std::string xdim_name,
     const std::string ydim_name, const std::vector<int> dim_order, const std::string mask_name,
-    bool ignore_mask, bool px, bool py)
+    bool ignore_mask, bool px, bool py, bool tripolar)
 {
     return new Grid(
-        comm, filename, xdim_name, ydim_name, dim_order, mask_name, ignore_mask, px, py);
+        comm, filename, xdim_name, ydim_name, dim_order, mask_name, ignore_mask, px, py, tripolar);
 }
 
 void Grid::ReadGridExtents(const std::string& filename)
@@ -131,13 +132,23 @@ void Grid::ReadGridMask(const std::string& filename, const std::string& mask_nam
 
 Grid::Grid(MPI_Comm comm, const std::string& filename, const std::string& xdim_name,
     const std::string& ydim_name, const std::vector<int>& dim_order, const std::string& mask_name,
-    bool ignore_mask, bool px, bool py)
+    bool ignore_mask, bool px, bool py, bool tripolar)
     : _comm(comm)
     , _dim_names({ xdim_name, ydim_name })
     , _dim_order(dim_order)
     , _px(px)
     , _py(py)
+    , _tripolar(tripolar)
 {
+
+    // Tripolar grid cannot be periodic
+    if (_tripolar && (_px || _py)) {
+        // TODO:
+        //  - Improve error message
+        //  - Verify conventions our for error handling
+        throw std::invalid_argument(
+            "Tripolar topology and periodic BCs are toggled at the same time");
+    }
 
     CHECK_MPI(MPI_Comm_rank(comm, &_rank));
 
@@ -204,6 +215,8 @@ int Grid::get_num_nonzero_objects() const { return _num_nonzero_objects; }
 bool Grid::get_px() const { return _px; }
 
 bool Grid::get_py() const { return _py; }
+
+bool Grid::get_tripolar() const { return _tripolar; }
 
 std::vector<int> Grid::getNumProcs() const { return _numProcs; }
 

--- a/Grid.hpp
+++ b/Grid.hpp
@@ -74,16 +74,17 @@ public:
      * @param ignore_mask Should the land mask be ignored
      * @param px Is the domain periodic in the x-direction
      * @param py Is the domain periodic in the y-direction
+     * @param tripolar True if the grid assumes tripolar grid topology (exclusive wrt px & py)
      * @return A distributed 2D grid object partitioned evenly in terms of grid
      * points.
      */
     // We are using the named constructor idiom so that objects can only be
     // created in the heap to ensure it's dtor is executed before MPI_Finalize()
     static Grid* create(MPI_Comm comm, const std::string& filename, bool ignore_mask = false,
-        bool px = false, bool py = false);
+        bool px = false, bool py = false, bool tripolar = false);
     static Grid* create(MPI_Comm comm, const std::string& filename, const std::string xdim_name,
         const std::string ydim_name, const std::vector<int> dim_order, const std::string mask_name,
-        bool ignore_mask = false, bool px = false, bool py = false);
+        bool ignore_mask = false, bool px = false, bool py = false, bool tripolar = false);
 
     /*!
      * @brief Returns the total number of objects in the local domain.
@@ -149,6 +150,12 @@ public:
     bool get_py() const;
 
     /*!
+     * @brief Return true if grid has tripolar topology
+       @return true if topology is tripolar
+    */
+    bool get_tripolar() const;
+
+    /*!
      * @brief Returns the index mapping of sparse to dense representation, where
      * dim0 is the 1st dimension and dim1 is the 2nd, with dim1 varying the
      * fastest in terms of storage.
@@ -182,7 +189,7 @@ private:
         const std::string& dim1_id = "y",
         const std::vector<int>& dim_order = std::vector<int>({ 1, 0 }),
         const std::string& mask_id = "mask", bool ignore_mask = false, bool px = false,
-        bool py = false);
+        bool py = false, bool tripolar = false);
 
     /*!
      * @brief Read dims from netcdf grid file.
@@ -235,6 +242,7 @@ private:
     int _num_nonzero_objects = 0; // Number of non-land grid points
     bool _px = false; // Periodicity in the x-direction
     bool _py = false; // Periodicity in the y-direction
+    bool _tripolar; // Assume tripolar topology
     std::vector<int> _land_mask = {}; // Land mask values
     std::vector<int> _local_id = {}; // Map from sparse to dense index
     std::vector<int> _global_id = {}; // Unique non-land grid point IDs

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -281,33 +281,6 @@ void Partitioner::getNeighbourInfo(std::array<std::vector<int>, N_EDGE>& ids,
     }
 }
 
-void Partitioner::getNeighbourInfoPeriodic(std::array<std::vector<int>, N_EDGE>& ids,
-    std::array<std::vector<int>, N_EDGE>& haloSizes, std::array<std::vector<int>, N_EDGE>& haloSend,
-    std::array<std::vector<int>, N_EDGE>& haloRecv,
-    std::array<std::vector<int>, N_CORNER>& cornerIds,
-    std::array<std::vector<int>, N_CORNER>& cornerSend) const
-{
-    for (auto edge : edges) {
-        if (((edge == LEFT || edge == RIGHT) && _px) || ((edge == TOP || edge == BOTTOM) && _py)) {
-
-            for (auto it = _neighbours_p[edge].begin(); it != _neighbours_p[edge].end(); ++it) {
-                ids[edge].push_back(it->first);
-                haloSizes[edge].push_back(it->second);
-                haloSend[edge].push_back(_sendPos_p[edge].at(it->first));
-                haloRecv[edge].push_back(_recvPos_p[edge].at(it->first));
-            }
-        }
-    }
-
-    for (auto corner : corners) {
-        for (auto it = _cornerNeighbours_p[corner].begin(); it != _cornerNeighbours_p[corner].end();
-             ++it) {
-            cornerIds[corner].push_back(it->first);
-            cornerSend[corner].push_back(_cornerSendPos_p[corner].at(it->first));
-        }
-    }
-}
-
 void Partitioner::saveMask(const std::string& filename) const
 {
     // Use C API for parallel I/O
@@ -388,29 +361,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
             &numCornerNeighbours[corner], &corner_offsets[corner], 1, MPI_INT, MPI_SUM, _comm));
     }
 
-    // Prepare periodic neighbour data
-    std::array<std::vector<int>, N_EDGE> ids_p, halos_p, haloSend_p, haloRecv_p;
-    std::array<std::vector<int>, N_CORNER> corner_ids_p, cornerSend_p;
-    getNeighbourInfoPeriodic(ids_p, halos_p, haloSend_p, haloRecv_p, corner_ids_p, cornerSend_p);
-    std::vector<int> num_neighbours_p(N_EDGE), dims_p(N_EDGE, 0), offsets_p(N_EDGE, 0);
-    for (auto edge : edges) {
-        num_neighbours_p[edge] = (int)ids_p[edge].size();
-        CHECK_MPI(
-            MPI_Allreduce(&num_neighbours_p[edge], &dims_p[edge], 1, MPI_INT, MPI_SUM, _comm));
-        CHECK_MPI(
-            MPI_Exscan(&num_neighbours_p[edge], &offsets_p[edge], 1, MPI_INT, MPI_SUM, _comm));
-    }
-
-    std::vector<int> numCornerNeighbours_p(N_CORNER), corner_dims_p(N_CORNER, 0),
-        corner_offsets_p(N_CORNER, 0);
-    for (auto corner : corners) {
-        numCornerNeighbours_p[corner] = (int)corner_ids_p[corner].size();
-        CHECK_MPI(MPI_Allreduce(
-            &numCornerNeighbours_p[corner], &corner_dims_p[corner], 1, MPI_INT, MPI_SUM, _comm));
-        CHECK_MPI(MPI_Exscan(
-            &numCornerNeighbours_p[corner], &corner_offsets_p[corner], 1, MPI_INT, MPI_SUM, _comm));
-    }
-
     // Define dimensions in netCDF file
     int dimid;
     std::vector<int> dimids(N_EDGE);
@@ -423,19 +373,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
     for (auto corner : corners) {
         NC_CHECK(nc_def_dim(
             nc_id, corner_dir_chars[corner].c_str(), corner_dims[corner], &corner_dimids[corner]));
-    }
-
-    // Define periodic dimensions in netCDF file
-    std::vector<int> dimids_p(N_EDGE);
-    for (auto edge : edges) {
-        NC_CHECK(nc_def_dim(
-            nc_id, (dir_chars[edge] + "_periodic").c_str(), dims_p[edge], &dimids_p[edge]));
-    }
-
-    std::vector<int> corner_dimids_p(N_CORNER);
-    for (auto edge : edges) {
-        NC_CHECK(nc_def_dim(nc_id, (corner_dir_chars[edge] + "_periodic").c_str(),
-            corner_dims_p[edge], &corner_dimids_p[edge]));
     }
 
     // Define groups in netCDF file
@@ -487,44 +424,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
                 NC_INT, 1, &corner_dimids[corner], &cornerSend_vid[corner]));
     }
 
-    int num_vid_p[N_EDGE];
-    int ids_vid_p[N_EDGE];
-    int halos_vid_p[N_EDGE];
-    int haloSend_vid_p[N_EDGE];
-    int haloRecv_vid_p[N_EDGE];
-    for (auto edge : edges) {
-        // Periodic members of connectivity group
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbours_periodic").c_str(),
-            NC_INT, 1, &dimid, &num_vid_p[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_ids_periodic").c_str(),
-            NC_INT, 1, &dimids_p[edge], &ids_vid_p[edge]));
-        NC_CHECK(
-            nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halos_periodic").c_str(),
-                NC_INT, 1, &dimids_p[edge], &halos_vid_p[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid,
-            (dir_names[edge] + "_neighbour_halo_send_periodic").c_str(), NC_INT, 1, &dimids_p[edge],
-            &haloSend_vid_p[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid,
-            (dir_names[edge] + "_neighbour_halo_recv_periodic").c_str(), NC_INT, 1, &dimids_p[edge],
-            &haloRecv_vid_p[edge]));
-    }
-
-    int num_corner_vid_p[N_CORNER];
-    int ids_corner_vid_p[N_CORNER];
-    int cornerSend_vid_p[N_CORNER];
-    for (auto corner : corners) {
-        // Connectivity group
-        NC_CHECK(nc_def_var(connectivity_gid,
-            (corner_dir_names[corner] + "_neighbours_periodic").c_str(), NC_INT, 1, &dimid,
-            &num_corner_vid_p[corner]));
-        NC_CHECK(nc_def_var(connectivity_gid,
-            (corner_dir_names[corner] + "_neighbour_ids_periodic").c_str(), NC_INT, 1,
-            &corner_dimids_p[corner], &ids_corner_vid_p[corner]));
-        NC_CHECK(nc_def_var(connectivity_gid,
-            (corner_dir_names[corner] + "_neighbour_send_periodic").c_str(), NC_INT, 1,
-            &corner_dimids_p[corner], &cornerSend_vid_p[corner]));
-    }
-
     // Write metadata to file
     NC_CHECK(nc_enddef(nc_id));
 
@@ -541,10 +440,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
         size_t start = _rank;
         NC_CHECK(nc_var_par_access(connectivity_gid, num_vid[edge], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(connectivity_gid, num_vid[edge], &start, &num_neighbours[edge]));
-        // Numbers of neighbours for periodic dimensions
-        NC_CHECK(nc_var_par_access(connectivity_gid, num_vid_p[edge], NC_COLLECTIVE));
-        NC_CHECK(
-            nc_put_var1_int(connectivity_gid, num_vid_p[edge], &start, &num_neighbours_p[edge]));
         // IDs and halos
         start = offsets[edge];
         size_t count = num_neighbours[edge];
@@ -559,19 +454,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
             connectivity_gid, haloSend_vid[edge], &start, &count, haloSend[edge].data()));
         NC_CHECK(nc_put_vara_int(
             connectivity_gid, haloRecv_vid[edge], &start, &count, haloRecv[edge].data()));
-        // IDs and halos for periodic dimensions
-        start = offsets_p[edge];
-        count = num_neighbours_p[edge];
-        NC_CHECK(nc_var_par_access(connectivity_gid, ids_vid_p[edge], NC_COLLECTIVE));
-        NC_CHECK(
-            nc_put_vara_int(connectivity_gid, ids_vid_p[edge], &start, &count, ids_p[edge].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid_p[edge], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, halos_vid_p[edge], &start, &count, halos_p[edge].data()));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, haloSend_vid_p[edge], &start, &count, haloSend_p[edge].data()));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, haloRecv_vid_p[edge], &start, &count, haloRecv_p[edge].data()));
     }
 
     for (auto corner : corners) {
@@ -580,10 +462,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
         NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_var1_int(
             connectivity_gid, num_corner_vid[corner], &start, &numCornerNeighbours[corner]));
-        // Numbers of corner neighbours for periodic dimensions
-        NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid_p[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(
-            connectivity_gid, num_corner_vid_p[corner], &start, &numCornerNeighbours_p[corner]));
 
         // "Corner" IDs and halos
         start = corner_offsets[corner];
@@ -594,16 +472,6 @@ void Partitioner::saveMetadata(const std::string& filename) const
         NC_CHECK(nc_var_par_access(connectivity_gid, cornerSend_vid[corner], NC_COLLECTIVE));
         NC_CHECK(nc_put_vara_int(
             connectivity_gid, cornerSend_vid[corner], &start, &count, cornerSend[corner].data()));
-
-        // "Corner" IDs and halos for periodic dimensions
-        start = corner_offsets_p[corner];
-        count = numCornerNeighbours_p[corner];
-        NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid_p[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(connectivity_gid, ids_corner_vid_p[corner], &start, &count,
-            corner_ids_p[corner].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid_p[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(connectivity_gid, cornerSend_vid_p[corner], &start, &count,
-            cornerSend_p[corner].data()));
     }
 
     NC_CHECK(nc_close(nc_id));
@@ -725,34 +593,30 @@ void Partitioner::discover_neighbours()
             }
         }
 
-        // When finding neighours *across periodic boundaries*, we need to check against the
+        // When finding neighbours *across periodic boundaries*, we need to check against the
         // current rank, too, because a subdomain can be a periodic neighbour of itself.
-        // check periodic edge neighours
+        // check periodic edge neighbours
         for (auto edge : edges) {
             if (isNeighbour(domains[_rank], domains[p], edge, _px, _py)) {
                 int haloSize = domainOverlap(domains[_rank], domains[p], edge);
                 if (haloSize > 0) {
-                    _neighbours_p[edge].insert(std::pair<int, int>(p, haloSize));
+                    _neighbours[edge].insert(std::pair<int, int>(p, haloSize));
                     int sendPos = 0;
                     int recvPos = 0;
                     haloEdgeBufferPositions(domains[_rank], domains[p], edge, sendPos, recvPos);
-                    _sendPos_p[edge].insert(std::pair<int, int>(p, sendPos));
-                    _recvPos_p[edge].insert(std::pair<int, int>(p, recvPos));
+                    _sendPos[edge].insert(std::pair<int, int>(p, sendPos));
+                    _recvPos[edge].insert(std::pair<int, int>(p, recvPos));
                 }
             }
         }
 
-        // check periodic corner neighours
+        // check periodic corner neighbours
         for (auto corner : corners) {
             if (isCornerNeighbour(domains[_rank], domains[p], corner, _px, _py)) {
-                if (_cornerNeighbours[corner].size() > 0) {
-                    // skip if we have already counted as a non-periodic neighbour
-                    continue;
-                }
-                _cornerNeighbours_p[corner].insert(std::pair<int, int>(p, 1));
+                _cornerNeighbours[corner].insert(std::pair<int, int>(p, 1));
                 int sendPos = 0;
                 haloCornerBufferPositions(domains[_rank], domains[p], corner, sendPos);
-                _cornerSendPos_p[corner].insert(std::pair<int, int>(p, sendPos));
+                _cornerSendPos[corner].insert(std::pair<int, int>(p, sendPos));
             }
         }
     }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -566,6 +566,9 @@ void Partitioner::discover_neighbours()
         domains[p].p2.y = origins[p].y + extents[p].y;
     }
 
+    const bool usePeriodicX = _px || _tripolar;
+    const bool usePeriodicY = _py;
+
     for (int p = 0; p < _totalNumProcs; p++) {
 
         // When finding neighbours *within* the domain, we don't check against the current rank
@@ -602,7 +605,7 @@ void Partitioner::discover_neighbours()
         // current rank, too, because a subdomain can be a periodic neighbour of itself.
         // check periodic edge neighbours
         for (auto edge : edges) {
-            if (isNeighbour(domains[_rank], domains[p], edge, _px, _py)) {
+            if (isNeighbour(domains[_rank], domains[p], edge, usePeriodicX, usePeriodicY)) {
                 int haloSize = domainOverlap(domains[_rank], domains[p], edge);
                 if (haloSize > 0) {
                     _neighbours[edge].insert(std::pair<int, int>(p, haloSize));
@@ -617,11 +620,74 @@ void Partitioner::discover_neighbours()
 
         // check periodic corner neighbours
         for (auto corner : corners) {
-            if (isCornerNeighbour(domains[_rank], domains[p], corner, _px, _py)) {
+            if (isCornerNeighbour(domains[_rank], domains[p], corner, usePeriodicX, usePeriodicY)) {
                 _cornerNeighbours[corner].insert(std::pair<int, int>(p, 1));
                 int sendPos = 0;
                 haloCornerBufferPositions(domains[_rank], domains[p], corner, sendPos);
                 _cornerSendPos[corner].insert(std::pair<int, int>(p, sendPos));
+            }
+        }
+    }
+
+    // For tripolar topology apply special treatment to the top edge
+    // To correctly resolve the neighbourhood relations, we just need to create
+    // an 'image' of the domain on the other side of the tripolar top edge.
+    // This is just a point symmetry through the "middle point" of the top edge
+    //
+    // The only difficulty comes from calculating the send and receive buffer
+    // positions.
+    //
+    // For `send` buffers these are calculated on the 'target' domain.
+    // Hence we need to use the image of the current domain to get correct orientation.
+    //
+    // For the `recv` buffers, these are calculated on the 'current' domain.
+    // Hence we use the image of the target
+    //
+    if (_tripolar) {
+        const Domain& thisDomain = domains[_rank];
+        const Point symmetryPoint = { _globalExt[0] / 2, _globalExt[1] };
+
+        // Resolve Edge Neighbours
+        for (int p = 0; p < _totalNumProcs; p++) {
+            const Domain image = pointReflection(symmetryPoint, domains[p]);
+            const Domain selfImage = pointReflection(symmetryPoint, thisDomain);
+
+            // Now we can check for the neighbourhood relation with the image
+            if (isNeighbour(thisDomain, image, TOP)) {
+                const int haloSize = domainOverlap(thisDomain, image, TOP);
+
+                if (haloSize > 0) {
+                    _neighbours[TOP].insert(std::pair<int, int>(p, haloSize));
+
+                    int sendPos, recvPos, dontCare;
+
+                    // Calculate the receive position on self
+                    haloEdgeBufferPositions(thisDomain, image, TOP, dontCare, recvPos);
+
+                    // Calculate the send position on the image
+                    haloEdgeBufferPositions(selfImage, domains[p], BOTTOM, sendPos, dontCare);
+
+                    _sendPos[TOP].insert(std::pair<int, int>(p, sendPos));
+                    _recvPos[TOP].insert(std::pair<int, int>(p, recvPos));
+                }
+            }
+
+            if (isCornerNeighbour(thisDomain, image, TOP_LEFT)) {
+                _cornerNeighbours[TOP_LEFT].insert(std::pair<int, int>(p, 1));
+
+                int sendPos;
+                haloCornerBufferPositions(selfImage, domains[p], BOTTOM_RIGHT, sendPos);
+
+                _cornerSendPos[TOP_LEFT].insert(std::pair<int, int>(p, sendPos));
+            }
+
+            if (isCornerNeighbour(thisDomain, image, TOP_RIGHT)) {
+                _cornerNeighbours[TOP_RIGHT].insert(std::pair<int, int>(p, 1));
+
+                int sendPos;
+                haloCornerBufferPositions(selfImage, domains[p], BOTTOM_LEFT, sendPos);
+
+                _cornerSendPos[TOP_RIGHT].insert(std::pair<int, int>(p, sendPos));
             }
         }
     }

--- a/Partitioner.cpp
+++ b/Partitioner.cpp
@@ -321,6 +321,28 @@ void Partitioner::saveMask(const std::string& filename) const
     NC_CHECK(nc_close(nc_id));
 }
 
+struct DimInfo {
+    std::vector<int> numNeighbours;
+    std::vector<int> dims;
+    std::vector<int> offsets;
+};
+
+template <typename T, std::size_t N>
+static DimInfo compute_dims(
+    const std::array<T, N>& items, const std::array<std::vector<int>, N>& data, MPI_Comm comm)
+{
+    DimInfo info;
+    info.numNeighbours.resize(items.size());
+    info.dims.resize(items.size(), 0);
+    info.offsets.resize(items.size(), 0);
+    for (std::size_t i = 0; i < items.size(); i++) {
+        info.numNeighbours[i] = (int)data[items[i]].size();
+        CHECK_MPI(MPI_Allreduce(&info.numNeighbours[i], &info.dims[i], 1, MPI_INT, MPI_SUM, comm));
+        CHECK_MPI(MPI_Exscan(&info.numNeighbours[i], &info.offsets[i], 1, MPI_INT, MPI_SUM, comm));
+    }
+    return info;
+}
+
 void Partitioner::saveMetadata(const std::string& filename) const
 {
     // Use C API for parallel I/O
@@ -328,150 +350,133 @@ void Partitioner::saveMetadata(const std::string& filename) const
     nc_mode = NC_MPIIO | NC_NETCDF4;
     NC_CHECK(nc_create_par(filename.c_str(), nc_mode, _comm, MPI_INFO_NULL, &nc_id));
 
-    // Create 2 dimensions
-    // The values to be written are associated with the netCDF variable by
-    // assuming that the last dimension of the netCDF variable varies fastest in
-    // the C interface
-    const int NDIMS = 2; // TODO: Why redeclared?
-    int dimid_global[NDIMS];
-    for (int idx = 0; idx < NDIMS; idx++) {
-        NC_CHECK(
-            nc_def_dim(nc_id, globalExtentNames[idx].c_str(), _globalExt[idx], &dimid_global[idx]));
+    // utility lambdas for netcdf operations
+    // define a new dimension
+    auto def_dim = [&](const std::string& name, int len, int& dimid) {
+        NC_CHECK(nc_def_dim(nc_id, name.c_str(), len, &dimid));
+    };
+
+    // write an array to netcdf file
+    auto write_array = [&](int gid, int vid, size_t start, size_t count, const int* data) {
+        NC_CHECK(nc_var_par_access(gid, vid, NC_COLLECTIVE));
+        NC_CHECK(nc_put_vara_int(gid, vid, &start, &count, data));
+    };
+
+    // write a scalar to netcdf file
+    auto write_scalar = [&](int gid, int vid, size_t start, int val) {
+        NC_CHECK(nc_var_par_access(gid, vid, NC_COLLECTIVE));
+        NC_CHECK(nc_put_var1_int(gid, vid, &start, &val));
+    };
+
+    // ---- Global dimensions (NX, NY) ----
+    int dimid_global[Partitioner::NDIMS];
+    for (int idx = 0; idx < Partitioner::NDIMS; idx++) {
+        def_dim(globalExtentNames[idx], _globalExt[idx], dimid_global[idx]);
     }
 
-    // Prepare neighbour data
+    // ---- Prepare neighbour data ----
     std::array<std::vector<int>, N_EDGE> ids, halos, haloSend, haloRecv;
     std::array<std::vector<int>, N_CORNER> corner_ids, cornerSend;
     getNeighbourInfo(ids, halos, haloSend, haloRecv, corner_ids, cornerSend);
 
-    std::vector<int> num_neighbours(N_EDGE), dims(N_EDGE, 0), offsets(N_EDGE, 0);
-    for (auto edge : edges) {
-        num_neighbours[edge] = (int)ids[edge].size();
-        CHECK_MPI(MPI_Allreduce(&num_neighbours[edge], &dims[edge], 1, MPI_INT, MPI_SUM, _comm));
-        CHECK_MPI(MPI_Exscan(&num_neighbours[edge], &offsets[edge], 1, MPI_INT, MPI_SUM, _comm));
-    }
+    // ---- Compute edge dimensions (MPI Allreduce/Exscan) ----
+    DimInfo edge_info = compute_dims(edges, ids, _comm);
+    DimInfo corner_info = compute_dims(corners, corner_ids, _comm);
 
-    std::vector<int> numCornerNeighbours(N_CORNER), corner_dims(N_CORNER, 0),
-        corner_offsets(N_CORNER, 0);
-    for (auto corner : corners) {
-        numCornerNeighbours[corner] = (int)corner_ids[corner].size();
-        CHECK_MPI(MPI_Allreduce(
-            &numCornerNeighbours[corner], &corner_dims[corner], 1, MPI_INT, MPI_SUM, _comm));
-        CHECK_MPI(MPI_Exscan(
-            &numCornerNeighbours[corner], &corner_offsets[corner], 1, MPI_INT, MPI_SUM, _comm));
-    }
-
-    // Define dimensions in netCDF file
+    // ---- Define netCDF dimensions ----
     int dimid;
-    std::vector<int> dimids(N_EDGE);
+    std::vector<int> edge_dimids(N_EDGE);
+    std::vector<int> corner_dimids(N_CORNER);
+
     NC_CHECK(nc_def_dim(nc_id, "P", _totalNumProcs, &dimid));
     for (auto edge : edges) {
-        NC_CHECK(nc_def_dim(nc_id, dir_chars[edge].c_str(), dims[edge], &dimids[edge]));
+        def_dim(dir_chars[edge], edge_info.dims[edge], edge_dimids[edge]);
     }
-
-    std::vector<int> corner_dimids(N_CORNER);
     for (auto corner : corners) {
-        NC_CHECK(nc_def_dim(
-            nc_id, corner_dir_chars[corner].c_str(), corner_dims[corner], &corner_dimids[corner]));
+        def_dim(corner_dir_chars[corner], corner_info.dims[corner], corner_dimids[corner]);
     }
 
-    // Define groups in netCDF file
-    int bbox_gid, connectivity_gid;
+    // ---- Define groups ----
+    int bbox_gid, c_grid;
     NC_CHECK(nc_def_grp(nc_id, "bounding_boxes", &bbox_gid));
-    NC_CHECK(nc_def_grp(nc_id, "connectivity", &connectivity_gid));
+    NC_CHECK(nc_def_grp(nc_id, "connectivity", &c_grid));
 
-    // Define variables in netCDF file
-    int top_vid[NDIMS];
-    int cnt_vid[NDIMS];
-    int num_vid[N_EDGE];
-    for (int idx = 0; idx < NDIMS; idx++) {
-        // Bounding boxes group
-        NC_CHECK(nc_def_var(
-            bbox_gid, ("domain_" + dim_chars[idx]).c_str(), NC_INT, 1, &dimid, &top_vid[idx]));
-        NC_CHECK(nc_def_var(bbox_gid, ("domain_extent_" + dim_chars[idx]).c_str(), NC_INT, 1,
-            &dimid, &cnt_vid[idx]));
+    // ---- Define variables: bounding boxes ----
+    int top_vid[Partitioner::NDIMS];
+    int cnt_vid[Partitioner::NDIMS];
+    auto def_bbox_var = [&](const std::string& prefix, const auto idx, int& vid) {
+        NC_CHECK(nc_def_var(bbox_gid, (prefix + dim_chars[idx]).c_str(), NC_INT, 1, &dimid, &vid));
+    };
+    for (int idx = 0; idx < Partitioner::NDIMS; idx++) {
+        def_bbox_var("domain_", idx, top_vid[idx]);
+        def_bbox_var("domain_extent_", idx, cnt_vid[idx]);
     }
 
-    int ids_vid[N_EDGE];
-    int halos_vid[N_EDGE];
-    int haloSend_vid[N_EDGE];
-    int haloRecv_vid[N_EDGE];
-    for (auto edge : edges) {
-        // Connectivity group
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbours").c_str(), NC_INT, 1,
-            &dimid, &num_vid[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_ids").c_str(), NC_INT,
-            1, &dimids[edge], &ids_vid[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halos").c_str(),
-            NC_INT, 1, &dimids[edge], &halos_vid[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_send").c_str(),
-            NC_INT, 1, &dimids[edge], &haloSend_vid[edge]));
-        NC_CHECK(nc_def_var(connectivity_gid, (dir_names[edge] + "_neighbour_halo_recv").c_str(),
-            NC_INT, 1, &dimids[edge], &haloRecv_vid[edge]));
-    }
+    // ---- Define variables: edge connectivity ----
+    int num_vid[N_EDGE], ids_vid[N_EDGE], halos_vid[N_EDGE];
+    int haloSend_vid[N_EDGE], haloRecv_vid[N_EDGE];
 
-    int num_corner_vid[N_CORNER];
-    int ids_corner_vid[N_CORNER];
-    int cornerSend_vid[N_CORNER];
-    for (auto corner : corners) {
-        // Connectivity group
-        NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbours").c_str(),
-            NC_INT, 1, &dimid, &num_corner_vid[corner]));
-        NC_CHECK(nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbour_ids").c_str(),
-            NC_INT, 1, &corner_dimids[corner], &ids_corner_vid[corner]));
+    // lambda to define netcdf variables (for edges)
+    auto def_edge_var = [&](const auto edge, const std::string& name, const int* dimArr,
+                            auto* vid) {
         NC_CHECK(
-            nc_def_var(connectivity_gid, (corner_dir_names[corner] + "_neighbour_send").c_str(),
-                NC_INT, 1, &corner_dimids[corner], &cornerSend_vid[corner]));
+            nc_def_var(c_grid, (dir_names[edge] + name).c_str(), NC_INT, 1, dimArr, &vid[edge]));
+    };
+    for (auto edge : edges) {
+        def_edge_var(edge, "_neighbours", &dimid, num_vid);
+        const auto* edgeDimId = &edge_dimids[edge];
+        def_edge_var(edge, "_neighbour_ids", edgeDimId, ids_vid);
+        def_edge_var(edge, "_neighbour_halos", edgeDimId, halos_vid);
+        def_edge_var(edge, "_neighbour_halo_send", edgeDimId, haloSend_vid);
+        def_edge_var(edge, "_neighbour_halo_recv", edgeDimId, haloRecv_vid);
     }
 
-    // Write metadata to file
+    // ---- Define variables: corner connectivity ----
+    int num_corner_vid[N_CORNER], ids_corner_vid[N_CORNER];
+    int cornerSend_vid[N_CORNER];
+    // lambda to define netcdf variables (for corners)
+    auto def_corner_var
+        = [&](const auto corner, const std::string& name, const int* dimArr, int* vid) {
+              NC_CHECK(nc_def_var(c_grid, (corner_dir_names[corner] + name).c_str(), NC_INT, 1,
+                  dimArr, &vid[corner]));
+          };
+    for (auto corner : corners) {
+        def_corner_var(corner, "_neighbours", &dimid, num_corner_vid);
+        const auto* cornerDimId = &corner_dimids[corner];
+        def_corner_var(corner, "_neighbour_ids", cornerDimId, ids_corner_vid);
+        def_corner_var(corner, "_neighbour_send", cornerDimId, cornerSend_vid);
+    }
+
+    // ---- Write ----
     NC_CHECK(nc_enddef(nc_id));
 
-    // Store data
-    for (int idx = 0; idx < NDIMS; idx++) {
+    // Bounding boxes: one value per process
+    for (int idx = 0; idx < Partitioner::NDIMS; idx++) {
         size_t start = _rank;
-        NC_CHECK(nc_var_par_access(bbox_gid, top_vid[idx], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(bbox_gid, top_vid[idx], &start, &_globalNew[idx]));
-        NC_CHECK(nc_var_par_access(bbox_gid, cnt_vid[idx], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(bbox_gid, cnt_vid[idx], &start, &_localExtNew[idx]));
+        write_scalar(bbox_gid, top_vid[idx], start, _globalNew[idx]);
+        write_scalar(bbox_gid, cnt_vid[idx], start, _localExtNew[idx]);
     }
+
+    // Edge connectivity
     for (auto edge : edges) {
-        // Numbers of neighbours
         size_t start = _rank;
-        NC_CHECK(nc_var_par_access(connectivity_gid, num_vid[edge], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(connectivity_gid, num_vid[edge], &start, &num_neighbours[edge]));
-        // IDs and halos
-        start = offsets[edge];
-        size_t count = num_neighbours[edge];
-        NC_CHECK(nc_var_par_access(connectivity_gid, ids_vid[edge], NC_COLLECTIVE));
-        NC_CHECK(
-            nc_put_vara_int(connectivity_gid, ids_vid[edge], &start, &count, ids[edge].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, halos_vid[edge], NC_COLLECTIVE));
-        NC_CHECK(
-            nc_put_vara_int(connectivity_gid, halos_vid[edge], &start, &count, halos[edge].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, haloSend_vid[edge], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, haloSend_vid[edge], &start, &count, haloSend[edge].data()));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, haloRecv_vid[edge], &start, &count, haloRecv[edge].data()));
+        size_t count = edge_info.numNeighbours[edge];
+        write_scalar(c_grid, num_vid[edge], start, edge_info.numNeighbours[edge]);
+        start = edge_info.offsets[edge];
+        write_array(c_grid, ids_vid[edge], start, count, ids[edge].data());
+        write_array(c_grid, halos_vid[edge], start, count, halos[edge].data());
+        write_array(c_grid, haloSend_vid[edge], start, count, haloSend[edge].data());
+        write_array(c_grid, haloRecv_vid[edge], start, count, haloRecv[edge].data());
     }
 
+    // Corner connectivity
     for (auto corner : corners) {
-        // Numbers of "corner" neighbours
         size_t start = _rank;
-        NC_CHECK(nc_var_par_access(connectivity_gid, num_corner_vid[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_var1_int(
-            connectivity_gid, num_corner_vid[corner], &start, &numCornerNeighbours[corner]));
-
-        // "Corner" IDs and halos
-        start = corner_offsets[corner];
-        size_t count = numCornerNeighbours[corner];
-        NC_CHECK(nc_var_par_access(connectivity_gid, ids_corner_vid[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, ids_corner_vid[corner], &start, &count, corner_ids[corner].data()));
-        NC_CHECK(nc_var_par_access(connectivity_gid, cornerSend_vid[corner], NC_COLLECTIVE));
-        NC_CHECK(nc_put_vara_int(
-            connectivity_gid, cornerSend_vid[corner], &start, &count, cornerSend[corner].data()));
+        size_t count = corner_info.numNeighbours[corner];
+        write_scalar(c_grid, num_corner_vid[corner], start, corner_info.numNeighbours[corner]);
+        start = corner_info.offsets[corner];
+        write_array(c_grid, ids_corner_vid[corner], start, count, corner_ids[corner].data());
+        write_array(c_grid, cornerSend_vid[corner], start, count, cornerSend[corner].data());
     }
 
     NC_CHECK(nc_close(nc_id));

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -123,6 +123,7 @@ protected:
     static const int NNBRS = 2 * NDIMS; // Number of neighbours (two per dimension)
     bool _px = false; // Periodic boundary in the x-direction
     bool _py = false; // Periodic boundary in the y-direction
+    bool _tripolar = false; // True for tripolar grid topology
 
     // Letters used for each dimension
     std::vector<std::string> dim_chars = { "x", "y" };

--- a/Partitioner.hpp
+++ b/Partitioner.hpp
@@ -75,23 +75,6 @@ public:
         std::array<std::vector<int>, N_CORNER>& cornerIds,
         std::array<std::vector<int>, N_CORNER>& cornerSend) const;
     /*!
-     * @brief Returns vectors containing the MPI ranks, halo sizes and halo starting indices of
-     * the neighbours of this process across periodic boundaries after partitioning. The
-     * neighbours are ordered left, right, bottom, top.
-     *
-     * @param ids MPI ranks of the periodic neighbours for each direction
-     * @param haloSizes Halo sizes of the periodic neighbours for each direction
-     * @param haloSend index in send buffer to get halo data
-     * @param haloRecv index in recv buffer to put halo data
-     */
-    void getNeighbourInfoPeriodic(std::array<std::vector<int>, N_EDGE>& ids,
-        std::array<std::vector<int>, N_EDGE>& haloSizes,
-        std::array<std::vector<int>, N_EDGE>& haloSend,
-        std::array<std::vector<int>, N_EDGE>& haloRecv,
-        std::array<std::vector<int>, N_CORNER>& cornerIds,
-        std::array<std::vector<int>, N_CORNER>& cornerSend) const;
-
-    /*!
      * @brief Saves the partition IDs of the latest 2D domain decomposition in a
      * NetCDF file.
      *
@@ -198,23 +181,6 @@ protected:
 
     // Vector of maps of "corner" neighbours to their halo start indices after partitioning
     std::vector<std::map<int, int>> _cornerSendPos = std::vector<std::map<int, int>>(NNBRS);
-
-    // Vector of maps of periodic neighbours to their halo sizes after partitioning
-    std::vector<std::map<int, int>> _neighbours_p = std::vector<std::map<int, int>>(NNBRS);
-
-    // Vector of maps of periodic neighbours to their send buffer indices - index of data to fetch
-    // from send buffer
-    std::vector<std::map<int, int>> _sendPos_p = std::vector<std::map<int, int>>(NNBRS);
-
-    // Vector of maps of periodic neighbours to their recv (receive) buffer indices - index where
-    // data will be stored in the recv buffer
-    std::vector<std::map<int, int>> _recvPos_p = std::vector<std::map<int, int>>(NNBRS);
-
-    // Vector of maps of "corner" neighbours to their halo sizes after partitioning
-    std::vector<std::map<int, int>> _cornerNeighbours_p = std::vector<std::map<int, int>>(NNBRS);
-
-    // Vector of maps of "corner" neighbours to their halo start indices after partitioning
-    std::vector<std::map<int, int>> _cornerSendPos_p = std::vector<std::map<int, int>>(NNBRS);
 
 public:
     struct LIB_EXPORT Factory {

--- a/ZoltanPartitioner.cpp
+++ b/ZoltanPartitioner.cpp
@@ -98,6 +98,9 @@ void ZoltanPartitioner::partition(Grid& grid)
     grid.get_bounding_box(_global[0], _global[1], _localExt[0], _localExt[1]);
     _px = grid.get_px();
     _py = grid.get_py();
+    // TODO: I am not really sure reading properties from a Grid
+    //  should happen in child classes... feels dangerous (to be discussed)
+    _tripolar = grid.get_tripolar();
 
     if (_totalNumProcs == 1) {
         for (int idx = 0; idx < 2; idx++) {

--- a/main.cpp
+++ b/main.cpp
@@ -54,7 +54,8 @@ int main(int argc, char* argv[])
         ("ignore-mask,i", po::bool_switch()->default_value(false), "Ignore mask in netCDF grid file")
         ("periodic-x,px", po::bool_switch()->default_value(false), "Periodicity in x-direction")
         ("periodic-y,py", po::bool_switch()->default_value(false), "Periodicity in y-direction")
-        ("output-prefix,op", po::value<string>()->default_value(""), "Prefix for output filenames");
+        ("output-prefix,op", po::value<string>()->default_value(""), "Prefix for output filenames")
+        ("tripolar", po::bool_switch()->default_value(false), "Use tripolar grid topology");
     // clang-format on
 
     // Parse optional command line options
@@ -86,7 +87,7 @@ int main(int argc, char* argv[])
     // Build grid from netCDF file
     Grid* grid = Grid::create(comm, vm["grid"].as<string>(), vm["xdim"].as<string>(),
         vm["ydim"].as<string>(), order, vm["mask"].as<string>(), vm["ignore-mask"].as<bool>(),
-        vm["periodic-x"].as<bool>(), vm["periodic-y"].as<bool>());
+        vm["periodic-x"].as<bool>(), vm["periodic-y"].as<bool>(), vm["tripolar"].as<bool>());
 
     // Create a Zoltan partitioner
     Partitioner* partitioner

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -66,10 +66,18 @@ add_custom_command(
         ncgen -b -o test_4.nc ${CMAKE_CURRENT_SOURCE_DIR}/test_4.cdl
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/test_4.cdl
 )
+
+add_custom_command(
+    OUTPUT tripolar_grid.nc
+    COMMAND
+        ncgen -b -o tripolar_grid.nc ${CMAKE_CURRENT_SOURCE_DIR}/tripolar_grid.cdl
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/tripolar_grid.cdl
+)
+
 add_custom_target(
     generate_input_files
     ALL
-    DEPENDS test_0.nc test_1.nc test_2.nc test_3.nc test_4.nc
+    DEPENDS test_0.nc test_1.nc test_2.nc test_3.nc test_4.nc tripolar_grid.nc
 )
 
 # integration test

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -14,6 +14,7 @@ declare -A FNAMES=(
   ["test_4_px"]="test_4.nc"
   ["test_4_py"]="test_4.nc"
   ["test_4_px_py"]="test_4.nc"
+  ["test_tripolar_2"]="tripolar_grid.nc"
 )
 
 # set flags for each integration test
@@ -28,6 +29,7 @@ declare -A FLAGS=(
   ["test_4_px"]="-x x -y y -m land_mask -o yx --px"
   ["test_4_py"]="-x x -y y -m land_mask -o yx --py"
   ["test_4_px_py"]="-x x -y y -m land_mask -o yx --px --py"
+  ["test_tripolar_2"]="-x x -y y -m mask --tripolar"
 )
 
 # run the domain decomp tool for each test case
@@ -50,6 +52,18 @@ for TEST in test_3 test_4 test_4_px test_4_py test_4_px_py; do
     ../decomp -g ${FNAMES[${TEST}]} ${FLAGS[${TEST}]} >/dev/null
 
   for filename in partition_mask_4 partition_metadata_4; do
+    ncdump "${filename}.nc" >"${filename}.cdl"
+    diff "${filename}.cdl" "${CMAKE_CURRENT_SOURCE_DIR}/${TEST}/ref_${filename}.cdl"
+  done
+  echo -e "\033[0;32mTest passed\033[0m"
+done
+
+for TEST in test_tripolar_2; do
+  echo "Running integration tripolar test '${TEST}'"
+  ${MPIEXEC} --oversubscribe ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} \
+    ../decomp -g ${FNAMES[${TEST}]} ${FLAGS[${TEST}]} >/dev/null
+
+  for filename in partition_mask_2 partition_metadata_2; do
     ncdump "${filename}.nc" >"${filename}.cdl"
     diff "${filename}.cdl" "${CMAKE_CURRENT_SOURCE_DIR}/${TEST}/ref_${filename}.cdl"
   done

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu
 
 # set filename for each integration test
 declare -A FNAMES=(

--- a/test/test_1/ref_partition_metadata_3.cdl
+++ b/test/test_1/ref_partition_metadata_3.cdl
@@ -11,14 +11,6 @@ dimensions:
 	TR = 1 ;
 	BR = 1 ;
 	BL = UNLIMITED ; // (0 currently)
-	L_periodic = UNLIMITED ; // (0 currently)
-	R_periodic = UNLIMITED ; // (0 currently)
-	B_periodic = UNLIMITED ; // (0 currently)
-	T_periodic = UNLIMITED ; // (0 currently)
-	TL_periodic = UNLIMITED ; // (0 currently)
-	TR_periodic = UNLIMITED ; // (0 currently)
-	BR_periodic = UNLIMITED ; // (0 currently)
-	BL_periodic = UNLIMITED ; // (0 currently)
 
 group: bounding_boxes {
   variables:
@@ -71,38 +63,6 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -160,21 +120,5 @@ group: connectivity {
    bottom_right_neighbour_send = 9 ;
 
    bottom_left_neighbours = 0, 0, 0 ;
-
-   left_neighbours_periodic = 0, 0, 0 ;
-
-   right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_neighbours_periodic = 0, 0, 0 ;
-
-   top_neighbours_periodic = 0, 0, 0 ;
-
-   top_left_neighbours_periodic = 0, 0, 0 ;
-
-   top_right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_left_neighbours_periodic = 0, 0, 0 ;
   } // group connectivity
 }

--- a/test/test_1_px/ref_partition_metadata_3.cdl
+++ b/test/test_1_px/ref_partition_metadata_3.cdl
@@ -3,22 +3,14 @@ dimensions:
 	NX = 6 ;
 	NY = 4 ;
 	P = 3 ;
-	L = 2 ;
-	R = 2 ;
+	L = 4 ;
+	R = 4 ;
 	B = 1 ;
 	T = 1 ;
-	TL = UNLIMITED ; // (0 currently)
+	TL = 1 ;
 	TR = 1 ;
 	BR = 1 ;
-	BL = UNLIMITED ; // (0 currently)
-	L_periodic = 2 ;
-	R_periodic = 2 ;
-	B_periodic = UNLIMITED ; // (0 currently)
-	T_periodic = UNLIMITED ; // (0 currently)
-	TL_periodic = 1 ;
-	TR_periodic = UNLIMITED ; // (0 currently)
-	BR_periodic = UNLIMITED ; // (0 currently)
-	BL_periodic = 1 ;
+	BL = 1 ;
 
 group: bounding_boxes {
   variables:
@@ -71,59 +63,27 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
-   left_neighbours = 0, 0, 2 ;
+   left_neighbours = 1, 1, 2 ;
 
-   left_neighbour_ids = 0, 1 ;
+   left_neighbour_ids = 2, 2, 0, 1 ;
 
-   left_neighbour_halos = 2, 2 ;
+   left_neighbour_halos = 2, 2, 2, 2 ;
 
-   left_neighbour_halo_send = 4, 4 ;
+   left_neighbour_halo_send = 2, 4, 4, 4 ;
 
-   left_neighbour_halo_recv = 8, 10 ;
+   left_neighbour_halo_recv = 10, 10, 8, 10 ;
 
-   right_neighbours = 1, 1, 0 ;
+   right_neighbours = 1, 1, 2 ;
 
-   right_neighbour_ids = 2, 2 ;
+   right_neighbour_ids = 2, 2, 0, 1 ;
 
-   right_neighbour_halos = 2, 2 ;
+   right_neighbour_halos = 2, 2, 2, 2 ;
 
-   right_neighbour_halo_send = 8, 10 ;
+   right_neighbour_halo_send = 8, 10, 10, 10 ;
 
-   right_neighbour_halo_recv = 4, 4 ;
+   right_neighbour_halo_recv = 4, 4, 2, 4 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -145,7 +105,11 @@ group: connectivity {
 
    top_neighbour_halo_recv = 6 ;
 
-   top_left_neighbours = 0, 0, 0 ;
+   top_left_neighbours = 1, 0, 0 ;
+
+   top_left_neighbour_ids = 2 ;
+
+   top_left_neighbour_send = 4 ;
 
    top_right_neighbours = 1, 0, 0 ;
 
@@ -159,46 +123,10 @@ group: connectivity {
 
    bottom_right_neighbour_send = 9 ;
 
-   bottom_left_neighbours = 0, 0, 0 ;
+   bottom_left_neighbours = 0, 1, 0 ;
 
-   left_neighbours_periodic = 1, 1, 0 ;
+   bottom_left_neighbour_ids = 2 ;
 
-   left_neighbour_ids_periodic = 2, 2 ;
-
-   left_neighbour_halos_periodic = 2, 2 ;
-
-   left_neighbour_halo_send_periodic = 2, 4 ;
-
-   left_neighbour_halo_recv_periodic = 10, 10 ;
-
-   right_neighbours_periodic = 0, 0, 2 ;
-
-   right_neighbour_ids_periodic = 0, 1 ;
-
-   right_neighbour_halos_periodic = 2, 2 ;
-
-   right_neighbour_halo_send_periodic = 10, 10 ;
-
-   right_neighbour_halo_recv_periodic = 2, 4 ;
-
-   bottom_neighbours_periodic = 0, 0, 0 ;
-
-   top_neighbours_periodic = 0, 0, 0 ;
-
-   top_left_neighbours_periodic = 1, 0, 0 ;
-
-   top_left_neighbour_ids_periodic = 2 ;
-
-   top_left_neighbour_send_periodic = 4 ;
-
-   top_right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_left_neighbours_periodic = 0, 1, 0 ;
-
-   bottom_left_neighbour_ids_periodic = 2 ;
-
-   bottom_left_neighbour_send_periodic = 3 ;
+   bottom_left_neighbour_send = 3 ;
   } // group connectivity
 }

--- a/test/test_1_px_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_px_py/ref_partition_metadata_3.cdl
@@ -3,22 +3,14 @@ dimensions:
 	NX = 6 ;
 	NY = 4 ;
 	P = 3 ;
-	L = 2 ;
-	R = 2 ;
-	B = 1 ;
-	T = 1 ;
-	TL = UNLIMITED ; // (0 currently)
-	TR = 1 ;
-	BR = 1 ;
-	BL = UNLIMITED ; // (0 currently)
-	L_periodic = 2 ;
-	R_periodic = 2 ;
-	B_periodic = 2 ;
-	T_periodic = 2 ;
-	TL_periodic = 3 ;
-	TR_periodic = 2 ;
-	BR_periodic = 2 ;
-	BL_periodic = 3 ;
+	L = 4 ;
+	R = 4 ;
+	B = 3 ;
+	T = 3 ;
+	TL = 3 ;
+	TR = 3 ;
+	BR = 3 ;
+	BL = 3 ;
 
 group: bounding_boxes {
   variables:
@@ -71,158 +63,70 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
-   left_neighbours = 0, 0, 2 ;
+   left_neighbours = 1, 1, 2 ;
 
-   left_neighbour_ids = 0, 1 ;
+   left_neighbour_ids = 2, 2, 0, 1 ;
 
-   left_neighbour_halos = 2, 2 ;
+   left_neighbour_halos = 2, 2, 2, 2 ;
 
-   left_neighbour_halo_send = 4, 4 ;
+   left_neighbour_halo_send = 2, 4, 4, 4 ;
 
-   left_neighbour_halo_recv = 8, 10 ;
+   left_neighbour_halo_recv = 10, 10, 8, 10 ;
 
-   right_neighbours = 1, 1, 0 ;
+   right_neighbours = 1, 1, 2 ;
 
-   right_neighbour_ids = 2, 2 ;
+   right_neighbour_ids = 2, 2, 0, 1 ;
 
-   right_neighbour_halos = 2, 2 ;
+   right_neighbour_halos = 2, 2, 2, 2 ;
 
-   right_neighbour_halo_send = 8, 10 ;
+   right_neighbour_halo_send = 8, 10, 10, 10 ;
 
-   right_neighbour_halo_recv = 4, 4 ;
+   right_neighbour_halo_recv = 4, 4, 2, 4 ;
 
-   bottom_neighbours = 0, 1, 0 ;
+   bottom_neighbours = 1, 1, 1 ;
 
-   bottom_neighbour_ids = 0 ;
+   bottom_neighbour_ids = 1, 0, 2 ;
 
-   bottom_neighbour_halos = 4 ;
+   bottom_neighbour_halos = 4, 4, 2 ;
 
-   bottom_neighbour_halo_send = 6 ;
+   bottom_neighbour_halo_send = 6, 6, 6 ;
 
-   bottom_neighbour_halo_recv = 0 ;
+   bottom_neighbour_halo_recv = 0, 0, 0 ;
 
-   top_neighbours = 1, 0, 0 ;
+   top_neighbours = 1, 1, 1 ;
 
-   top_neighbour_ids = 1 ;
+   top_neighbour_ids = 1, 0, 2 ;
 
-   top_neighbour_halos = 4 ;
+   top_neighbour_halos = 4, 4, 2 ;
 
-   top_neighbour_halo_send = 0 ;
+   top_neighbour_halo_send = 0, 0, 0 ;
 
-   top_neighbour_halo_recv = 6 ;
+   top_neighbour_halo_recv = 6, 6, 6 ;
 
-   top_left_neighbours = 0, 0, 0 ;
+   top_left_neighbours = 1, 1, 1 ;
 
-   top_right_neighbours = 1, 0, 0 ;
+   top_left_neighbour_ids = 2, 2, 0 ;
 
-   top_right_neighbour_ids = 2 ;
+   top_left_neighbour_send = 4, 2, 4 ;
 
-   top_right_neighbour_send = 10 ;
+   top_right_neighbours = 1, 1, 1 ;
 
-   bottom_right_neighbours = 0, 1, 0 ;
+   top_right_neighbour_ids = 2, 2, 0 ;
 
-   bottom_right_neighbour_ids = 2 ;
+   top_right_neighbour_send = 10, 8, 10 ;
 
-   bottom_right_neighbour_send = 9 ;
+   bottom_right_neighbours = 1, 1, 1 ;
 
-   bottom_left_neighbours = 0, 0, 0 ;
+   bottom_right_neighbour_ids = 2, 2, 1 ;
 
-   left_neighbours_periodic = 1, 1, 0 ;
+   bottom_right_neighbour_send = 11, 9, 11 ;
 
-   left_neighbour_ids_periodic = 2, 2 ;
+   bottom_left_neighbours = 1, 1, 1 ;
 
-   left_neighbour_halos_periodic = 2, 2 ;
+   bottom_left_neighbour_ids = 2, 2, 1 ;
 
-   left_neighbour_halo_send_periodic = 2, 4 ;
-
-   left_neighbour_halo_recv_periodic = 10, 10 ;
-
-   right_neighbours_periodic = 0, 0, 2 ;
-
-   right_neighbour_ids_periodic = 0, 1 ;
-
-   right_neighbour_halos_periodic = 2, 2 ;
-
-   right_neighbour_halo_send_periodic = 10, 10 ;
-
-   right_neighbour_halo_recv_periodic = 2, 4 ;
-
-   bottom_neighbours_periodic = 1, 0, 1 ;
-
-   bottom_neighbour_ids_periodic = 1, 2 ;
-
-   bottom_neighbour_halos_periodic = 4, 2 ;
-
-   bottom_neighbour_halo_send_periodic = 6, 6 ;
-
-   bottom_neighbour_halo_recv_periodic = 0, 0 ;
-
-   top_neighbours_periodic = 0, 1, 1 ;
-
-   top_neighbour_ids_periodic = 0, 2 ;
-
-   top_neighbour_halos_periodic = 4, 2 ;
-
-   top_neighbour_halo_send_periodic = 0, 0 ;
-
-   top_neighbour_halo_recv_periodic = 6, 6 ;
-
-   top_left_neighbours_periodic = 1, 1, 1 ;
-
-   top_left_neighbour_ids_periodic = 2, 2, 0 ;
-
-   top_left_neighbour_send_periodic = 4, 2, 4 ;
-
-   top_right_neighbours_periodic = 0, 1, 1 ;
-
-   top_right_neighbour_ids_periodic = 2, 0 ;
-
-   top_right_neighbour_send_periodic = 8, 10 ;
-
-   bottom_right_neighbours_periodic = 1, 0, 1 ;
-
-   bottom_right_neighbour_ids_periodic = 2, 1 ;
-
-   bottom_right_neighbour_send_periodic = 11, 11 ;
-
-   bottom_left_neighbours_periodic = 1, 1, 1 ;
-
-   bottom_left_neighbour_ids_periodic = 2, 2, 1 ;
-
-   bottom_left_neighbour_send_periodic = 5, 3, 5 ;
+   bottom_left_neighbour_send = 5, 3, 5 ;
   } // group connectivity
 }

--- a/test/test_1_py/ref_partition_metadata_3.cdl
+++ b/test/test_1_py/ref_partition_metadata_3.cdl
@@ -5,20 +5,12 @@ dimensions:
 	P = 3 ;
 	L = 2 ;
 	R = 2 ;
-	B = 1 ;
-	T = 1 ;
-	TL = UNLIMITED ; // (0 currently)
-	TR = 1 ;
-	BR = 1 ;
-	BL = UNLIMITED ; // (0 currently)
-	L_periodic = UNLIMITED ; // (0 currently)
-	R_periodic = UNLIMITED ; // (0 currently)
-	B_periodic = 2 ;
-	T_periodic = 2 ;
-	TL_periodic = 1 ;
-	TR_periodic = 1 ;
-	BR_periodic = 1 ;
-	BL_periodic = 1 ;
+	B = 3 ;
+	T = 3 ;
+	TL = 1 ;
+	TR = 2 ;
+	BR = 2 ;
+	BL = 1 ;
 
 group: bounding_boxes {
   variables:
@@ -71,38 +63,6 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -125,88 +85,48 @@ group: connectivity {
 
    right_neighbour_halo_recv = 4, 4 ;
 
-   bottom_neighbours = 0, 1, 0 ;
+   bottom_neighbours = 1, 1, 1 ;
 
-   bottom_neighbour_ids = 0 ;
+   bottom_neighbour_ids = 1, 0, 2 ;
 
-   bottom_neighbour_halos = 4 ;
+   bottom_neighbour_halos = 4, 4, 2 ;
 
-   bottom_neighbour_halo_send = 6 ;
+   bottom_neighbour_halo_send = 6, 6, 6 ;
 
-   bottom_neighbour_halo_recv = 0 ;
+   bottom_neighbour_halo_recv = 0, 0, 0 ;
 
-   top_neighbours = 1, 0, 0 ;
+   top_neighbours = 1, 1, 1 ;
 
-   top_neighbour_ids = 1 ;
+   top_neighbour_ids = 1, 0, 2 ;
 
-   top_neighbour_halos = 4 ;
+   top_neighbour_halos = 4, 4, 2 ;
 
-   top_neighbour_halo_send = 0 ;
+   top_neighbour_halo_send = 0, 0, 0 ;
 
-   top_neighbour_halo_recv = 6 ;
+   top_neighbour_halo_recv = 6, 6, 6 ;
 
-   top_left_neighbours = 0, 0, 0 ;
+   top_left_neighbours = 0, 0, 1 ;
 
-   top_right_neighbours = 1, 0, 0 ;
+   top_left_neighbour_ids = 0 ;
 
-   top_right_neighbour_ids = 2 ;
+   top_left_neighbour_send = 4 ;
 
-   top_right_neighbour_send = 10 ;
+   top_right_neighbours = 1, 1, 0 ;
 
-   bottom_right_neighbours = 0, 1, 0 ;
+   top_right_neighbour_ids = 2, 2 ;
 
-   bottom_right_neighbour_ids = 2 ;
+   top_right_neighbour_send = 10, 8 ;
 
-   bottom_right_neighbour_send = 9 ;
+   bottom_right_neighbours = 1, 1, 0 ;
 
-   bottom_left_neighbours = 0, 0, 0 ;
+   bottom_right_neighbour_ids = 2, 2 ;
 
-   left_neighbours_periodic = 0, 0, 0 ;
+   bottom_right_neighbour_send = 11, 9 ;
 
-   right_neighbours_periodic = 0, 0, 0 ;
+   bottom_left_neighbours = 0, 0, 1 ;
 
-   bottom_neighbours_periodic = 1, 0, 1 ;
+   bottom_left_neighbour_ids = 1 ;
 
-   bottom_neighbour_ids_periodic = 1, 2 ;
-
-   bottom_neighbour_halos_periodic = 4, 2 ;
-
-   bottom_neighbour_halo_send_periodic = 6, 6 ;
-
-   bottom_neighbour_halo_recv_periodic = 0, 0 ;
-
-   top_neighbours_periodic = 0, 1, 1 ;
-
-   top_neighbour_ids_periodic = 0, 2 ;
-
-   top_neighbour_halos_periodic = 4, 2 ;
-
-   top_neighbour_halo_send_periodic = 0, 0 ;
-
-   top_neighbour_halo_recv_periodic = 6, 6 ;
-
-   top_left_neighbours_periodic = 0, 0, 1 ;
-
-   top_left_neighbour_ids_periodic = 0 ;
-
-   top_left_neighbour_send_periodic = 4 ;
-
-   top_right_neighbours_periodic = 0, 1, 0 ;
-
-   top_right_neighbour_ids_periodic = 2 ;
-
-   top_right_neighbour_send_periodic = 8 ;
-
-   bottom_right_neighbours_periodic = 1, 0, 0 ;
-
-   bottom_right_neighbour_ids_periodic = 2 ;
-
-   bottom_right_neighbour_send_periodic = 11 ;
-
-   bottom_left_neighbours_periodic = 0, 0, 1 ;
-
-   bottom_left_neighbour_ids_periodic = 1 ;
-
-   bottom_left_neighbour_send_periodic = 5 ;
+   bottom_left_neighbour_send = 5 ;
   } // group connectivity
 }

--- a/test/test_2/ref_partition_metadata_3.cdl
+++ b/test/test_2/ref_partition_metadata_3.cdl
@@ -11,14 +11,6 @@ dimensions:
 	TR = UNLIMITED ; // (0 currently)
 	BR = UNLIMITED ; // (0 currently)
 	BL = UNLIMITED ; // (0 currently)
-	L_periodic = UNLIMITED ; // (0 currently)
-	R_periodic = UNLIMITED ; // (0 currently)
-	B_periodic = UNLIMITED ; // (0 currently)
-	T_periodic = UNLIMITED ; // (0 currently)
-	TL_periodic = UNLIMITED ; // (0 currently)
-	TR_periodic = UNLIMITED ; // (0 currently)
-	BR_periodic = UNLIMITED ; // (0 currently)
-	BL_periodic = UNLIMITED ; // (0 currently)
 
 group: bounding_boxes {
   variables:
@@ -71,38 +63,6 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
    left_neighbours = 0, 1, 1 ;
@@ -136,21 +96,5 @@ group: connectivity {
    bottom_right_neighbours = 0, 0, 0 ;
 
    bottom_left_neighbours = 0, 0, 0 ;
-
-   left_neighbours_periodic = 0, 0, 0 ;
-
-   right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_neighbours_periodic = 0, 0, 0 ;
-
-   top_neighbours_periodic = 0, 0, 0 ;
-
-   top_left_neighbours_periodic = 0, 0, 0 ;
-
-   top_right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_right_neighbours_periodic = 0, 0, 0 ;
-
-   bottom_left_neighbours_periodic = 0, 0, 0 ;
   } // group connectivity
 }

--- a/test/test_3/ref_partition_metadata_4.cdl
+++ b/test/test_3/ref_partition_metadata_4.cdl
@@ -11,14 +11,6 @@ dimensions:
 	TR = 1 ;
 	BR = 1 ;
 	BL = 1 ;
-	L_periodic = UNLIMITED ; // (0 currently)
-	R_periodic = UNLIMITED ; // (0 currently)
-	B_periodic = UNLIMITED ; // (0 currently)
-	T_periodic = UNLIMITED ; // (0 currently)
-	TL_periodic = UNLIMITED ; // (0 currently)
-	TR_periodic = UNLIMITED ; // (0 currently)
-	BR_periodic = UNLIMITED ; // (0 currently)
-	BL_periodic = UNLIMITED ; // (0 currently)
 
 group: bounding_boxes {
   variables:
@@ -71,38 +63,6 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
    left_neighbours = 0, 0, 1, 1 ;
@@ -168,21 +128,5 @@ group: connectivity {
    bottom_left_neighbour_ids = 0 ;
 
    bottom_left_neighbour_send = 5 ;
-
-   left_neighbours_periodic = 0, 0, 0, 0 ;
-
-   right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_left_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_left_neighbours_periodic = 0, 0, 0, 0 ;
   } // group connectivity
 }

--- a/test/test_4/ref_partition_metadata_4.cdl
+++ b/test/test_4/ref_partition_metadata_4.cdl
@@ -11,14 +11,6 @@ dimensions:
 	TR = 1 ;
 	BR = 1 ;
 	BL = 1 ;
-	L_periodic = UNLIMITED ; // (0 currently)
-	R_periodic = UNLIMITED ; // (0 currently)
-	B_periodic = UNLIMITED ; // (0 currently)
-	T_periodic = UNLIMITED ; // (0 currently)
-	TL_periodic = UNLIMITED ; // (0 currently)
-	TR_periodic = UNLIMITED ; // (0 currently)
-	BR_periodic = UNLIMITED ; // (0 currently)
-	BL_periodic = UNLIMITED ; // (0 currently)
 
 group: bounding_boxes {
   variables:
@@ -71,38 +63,6 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2, 1 ;
@@ -168,21 +128,5 @@ group: connectivity {
    bottom_left_neighbour_ids = 1 ;
 
    bottom_left_neighbour_send = 5 ;
-
-   left_neighbours_periodic = 0, 0, 0, 0 ;
-
-   right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_left_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_left_neighbours_periodic = 0, 0, 0, 0 ;
   } // group connectivity
 }

--- a/test/test_4_px/ref_partition_metadata_4.cdl
+++ b/test/test_4_px/ref_partition_metadata_4.cdl
@@ -3,22 +3,14 @@ dimensions:
 	NX = 7 ;
 	NY = 7 ;
 	P = 4 ;
-	L = 3 ;
-	R = 3 ;
+	L = 6 ;
+	R = 6 ;
 	B = 2 ;
 	T = 2 ;
-	TL = 1 ;
-	TR = 1 ;
-	BR = 1 ;
-	BL = 1 ;
-	L_periodic = 3 ;
-	R_periodic = 3 ;
-	B_periodic = UNLIMITED ; // (0 currently)
-	T_periodic = UNLIMITED ; // (0 currently)
-	TL_periodic = 1 ;
-	TR_periodic = 1 ;
-	BR_periodic = 1 ;
-	BL_periodic = 1 ;
+	TL = 2 ;
+	TR = 2 ;
+	BR = 2 ;
+	BL = 2 ;
 
 group: bounding_boxes {
   variables:
@@ -71,59 +63,27 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
-   left_neighbours = 0, 0, 2, 1 ;
+   left_neighbours = 1, 2, 2, 1 ;
 
-   left_neighbour_ids = 0, 1, 1 ;
+   left_neighbour_ids = 2, 2, 3, 0, 1, 1 ;
 
-   left_neighbour_halos = 2, 3, 2 ;
+   left_neighbour_halos = 2, 3, 2, 2, 3, 2 ;
 
-   left_neighbour_halo_send = 3, 3, 6 ;
+   left_neighbour_halo_send = 4, 6, 4, 3, 3, 6 ;
 
-   left_neighbour_halo_recv = 13, 15, 10 ;
+   left_neighbour_halo_recv = 8, 11, 14, 13, 15, 10 ;
 
-   right_neighbours = 1, 2, 0, 0 ;
+   right_neighbours = 1, 2, 2, 1 ;
 
-   right_neighbour_ids = 2, 2, 3 ;
+   right_neighbour_ids = 2, 2, 3, 0, 1, 1 ;
 
-   right_neighbour_halos = 2, 3, 2 ;
+   right_neighbour_halos = 2, 3, 2, 2, 3, 2 ;
 
-   right_neighbour_halo_send = 13, 15, 10 ;
+   right_neighbour_halo_send = 13, 15, 10, 8, 11, 14 ;
 
-   right_neighbour_halo_recv = 3, 3, 6 ;
+   right_neighbour_halo_recv = 3, 3, 6, 4, 6, 4 ;
 
    bottom_neighbours = 0, 1, 0, 1 ;
 
@@ -145,76 +105,28 @@ group: connectivity {
 
    top_neighbour_halo_recv = 5, 9 ;
 
-   top_left_neighbours = 0, 0, 1, 0 ;
+   top_left_neighbours = 1, 0, 1, 0 ;
 
-   top_left_neighbour_ids = 1 ;
+   top_left_neighbour_ids = 2, 1 ;
 
-   top_left_neighbour_send = 6 ;
+   top_left_neighbour_send = 6, 6 ;
 
-   top_right_neighbours = 1, 0, 0, 0 ;
+   top_right_neighbours = 1, 0, 1, 0 ;
 
-   top_right_neighbour_ids = 2 ;
+   top_right_neighbour_ids = 2, 1 ;
 
-   top_right_neighbour_send = 15 ;
+   top_right_neighbour_send = 15, 14 ;
 
-   bottom_right_neighbours = 0, 1, 0, 0 ;
+   bottom_right_neighbours = 0, 1, 0, 1 ;
 
-   bottom_right_neighbour_ids = 2 ;
+   bottom_right_neighbour_ids = 2, 1 ;
 
-   bottom_right_neighbour_send = 14 ;
+   bottom_right_neighbour_send = 14, 13 ;
 
-   bottom_left_neighbours = 0, 0, 0, 1 ;
+   bottom_left_neighbours = 0, 1, 0, 1 ;
 
-   bottom_left_neighbour_ids = 1 ;
+   bottom_left_neighbour_ids = 2, 1 ;
 
-   bottom_left_neighbour_send = 5 ;
-
-   left_neighbours_periodic = 1, 2, 0, 0 ;
-
-   left_neighbour_ids_periodic = 2, 2, 3 ;
-
-   left_neighbour_halos_periodic = 2, 3, 2 ;
-
-   left_neighbour_halo_send_periodic = 4, 6, 4 ;
-
-   left_neighbour_halo_recv_periodic = 8, 11, 14 ;
-
-   right_neighbours_periodic = 0, 0, 2, 1 ;
-
-   right_neighbour_ids_periodic = 0, 1, 1 ;
-
-   right_neighbour_halos_periodic = 2, 3, 2 ;
-
-   right_neighbour_halo_send_periodic = 8, 11, 14 ;
-
-   right_neighbour_halo_recv_periodic = 4, 6, 4 ;
-
-   bottom_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_neighbours_periodic = 0, 0, 0, 0 ;
-
-   top_left_neighbours_periodic = 1, 0, 0, 0 ;
-
-   top_left_neighbour_ids_periodic = 2 ;
-
-   top_left_neighbour_send_periodic = 6 ;
-
-   top_right_neighbours_periodic = 0, 0, 1, 0 ;
-
-   top_right_neighbour_ids_periodic = 1 ;
-
-   top_right_neighbour_send_periodic = 14 ;
-
-   bottom_right_neighbours_periodic = 0, 0, 0, 1 ;
-
-   bottom_right_neighbour_ids_periodic = 1 ;
-
-   bottom_right_neighbour_send_periodic = 13 ;
-
-   bottom_left_neighbours_periodic = 0, 1, 0, 0 ;
-
-   bottom_left_neighbour_ids_periodic = 2 ;
-
-   bottom_left_neighbour_send_periodic = 5 ;
+   bottom_left_neighbour_send = 5, 5 ;
   } // group connectivity
 }

--- a/test/test_4_px_py/ref_partition_metadata_4.cdl
+++ b/test/test_4_px_py/ref_partition_metadata_4.cdl
@@ -3,22 +3,14 @@ dimensions:
 	NX = 7 ;
 	NY = 7 ;
 	P = 4 ;
-	L = 3 ;
-	R = 3 ;
-	B = 2 ;
-	T = 2 ;
-	TL = 1 ;
-	TR = 1 ;
-	BR = 1 ;
-	BL = 1 ;
-	L_periodic = 3 ;
-	R_periodic = 3 ;
-	B_periodic = 2 ;
-	T_periodic = 2 ;
-	TL_periodic = 3 ;
-	TR_periodic = 3 ;
-	BR_periodic = 3 ;
-	BL_periodic = 3 ;
+	L = 6 ;
+	R = 6 ;
+	B = 4 ;
+	T = 4 ;
+	TL = 4 ;
+	TR = 4 ;
+	BR = 4 ;
+	BL = 4 ;
 
 group: bounding_boxes {
   variables:
@@ -71,166 +63,70 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
-   left_neighbours = 0, 0, 2, 1 ;
+   left_neighbours = 1, 2, 2, 1 ;
 
-   left_neighbour_ids = 0, 1, 1 ;
+   left_neighbour_ids = 2, 2, 3, 0, 1, 1 ;
 
-   left_neighbour_halos = 2, 3, 2 ;
+   left_neighbour_halos = 2, 3, 2, 2, 3, 2 ;
 
-   left_neighbour_halo_send = 3, 3, 6 ;
+   left_neighbour_halo_send = 4, 6, 4, 3, 3, 6 ;
 
-   left_neighbour_halo_recv = 13, 15, 10 ;
+   left_neighbour_halo_recv = 8, 11, 14, 13, 15, 10 ;
 
-   right_neighbours = 1, 2, 0, 0 ;
+   right_neighbours = 1, 2, 2, 1 ;
 
-   right_neighbour_ids = 2, 2, 3 ;
+   right_neighbour_ids = 2, 2, 3, 0, 1, 1 ;
 
-   right_neighbour_halos = 2, 3, 2 ;
+   right_neighbour_halos = 2, 3, 2, 2, 3, 2 ;
 
-   right_neighbour_halo_send = 13, 15, 10 ;
+   right_neighbour_halo_send = 13, 15, 10, 8, 11, 14 ;
 
-   right_neighbour_halo_recv = 3, 3, 6 ;
+   right_neighbour_halo_recv = 3, 3, 6, 4, 6, 4 ;
 
-   bottom_neighbours = 0, 1, 0, 1 ;
+   bottom_neighbours = 1, 1, 1, 1 ;
 
-   bottom_neighbour_ids = 0, 2 ;
+   bottom_neighbour_ids = 1, 0, 3, 2 ;
 
-   bottom_neighbour_halos = 3, 4 ;
+   bottom_neighbour_halos = 3, 3, 4, 4 ;
 
-   bottom_neighbour_halo_send = 5, 9 ;
+   bottom_neighbour_halo_send = 8, 5, 6, 9 ;
 
-   bottom_neighbour_halo_recv = 0, 0 ;
+   bottom_neighbour_halo_recv = 0, 0, 0, 0 ;
 
-   top_neighbours = 1, 0, 1, 0 ;
+   top_neighbours = 1, 1, 1, 1 ;
 
-   top_neighbour_ids = 1, 3 ;
+   top_neighbour_ids = 1, 0, 3, 2 ;
 
-   top_neighbour_halos = 3, 4 ;
+   top_neighbour_halos = 3, 3, 4, 4 ;
 
-   top_neighbour_halo_send = 0, 0 ;
+   top_neighbour_halo_send = 0, 0, 0, 0 ;
 
-   top_neighbour_halo_recv = 5, 9 ;
+   top_neighbour_halo_recv = 5, 8, 9, 6 ;
 
-   top_left_neighbours = 0, 0, 1, 0 ;
+   top_left_neighbours = 1, 1, 1, 1 ;
 
-   top_left_neighbour_ids = 1 ;
+   top_left_neighbour_ids = 2, 2, 1, 0 ;
 
-   top_left_neighbour_send = 6 ;
+   top_left_neighbour_send = 6, 4, 6, 3 ;
 
-   top_right_neighbours = 1, 0, 0, 0 ;
+   top_right_neighbours = 1, 1, 1, 1 ;
 
-   top_right_neighbour_ids = 2 ;
+   top_right_neighbour_ids = 2, 2, 1, 0 ;
 
-   top_right_neighbour_send = 15 ;
+   top_right_neighbour_send = 15, 13, 14, 8 ;
 
-   bottom_right_neighbours = 0, 1, 0, 0 ;
+   bottom_right_neighbours = 1, 1, 1, 1 ;
 
-   bottom_right_neighbour_ids = 2 ;
+   bottom_right_neighbour_ids = 3, 2, 1, 1 ;
 
-   bottom_right_neighbour_send = 14 ;
+   bottom_right_neighbour_send = 11, 14, 15, 13 ;
 
-   bottom_left_neighbours = 0, 0, 0, 1 ;
+   bottom_left_neighbours = 1, 1, 1, 1 ;
 
-   bottom_left_neighbour_ids = 1 ;
+   bottom_left_neighbour_ids = 3, 2, 1, 1 ;
 
-   bottom_left_neighbour_send = 5 ;
-
-   left_neighbours_periodic = 1, 2, 0, 0 ;
-
-   left_neighbour_ids_periodic = 2, 2, 3 ;
-
-   left_neighbour_halos_periodic = 2, 3, 2 ;
-
-   left_neighbour_halo_send_periodic = 4, 6, 4 ;
-
-   left_neighbour_halo_recv_periodic = 8, 11, 14 ;
-
-   right_neighbours_periodic = 0, 0, 2, 1 ;
-
-   right_neighbour_ids_periodic = 0, 1, 1 ;
-
-   right_neighbour_halos_periodic = 2, 3, 2 ;
-
-   right_neighbour_halo_send_periodic = 8, 11, 14 ;
-
-   right_neighbour_halo_recv_periodic = 4, 6, 4 ;
-
-   bottom_neighbours_periodic = 1, 0, 1, 0 ;
-
-   bottom_neighbour_ids_periodic = 1, 3 ;
-
-   bottom_neighbour_halos_periodic = 3, 4 ;
-
-   bottom_neighbour_halo_send_periodic = 8, 6 ;
-
-   bottom_neighbour_halo_recv_periodic = 0, 0 ;
-
-   top_neighbours_periodic = 0, 1, 0, 1 ;
-
-   top_neighbour_ids_periodic = 0, 2 ;
-
-   top_neighbour_halos_periodic = 3, 4 ;
-
-   top_neighbour_halo_send_periodic = 0, 0 ;
-
-   top_neighbour_halo_recv_periodic = 8, 6 ;
-
-   top_left_neighbours_periodic = 1, 1, 0, 1 ;
-
-   top_left_neighbour_ids_periodic = 2, 2, 0 ;
-
-   top_left_neighbour_send_periodic = 6, 4, 3 ;
-
-   top_right_neighbours_periodic = 0, 1, 1, 1 ;
-
-   top_right_neighbour_ids_periodic = 2, 1, 0 ;
-
-   top_right_neighbour_send_periodic = 13, 14, 8 ;
-
-   bottom_right_neighbours_periodic = 1, 0, 1, 1 ;
-
-   bottom_right_neighbour_ids_periodic = 3, 1, 1 ;
-
-   bottom_right_neighbour_send_periodic = 11, 15, 13 ;
-
-   bottom_left_neighbours_periodic = 1, 1, 1, 0 ;
-
-   bottom_left_neighbour_ids_periodic = 3, 2, 1 ;
-
-   bottom_left_neighbour_send_periodic = 5, 5, 7 ;
+   bottom_left_neighbour_send = 5, 5, 7, 5 ;
   } // group connectivity
 }

--- a/test/test_4_py/ref_partition_metadata_4.cdl
+++ b/test/test_4_py/ref_partition_metadata_4.cdl
@@ -5,20 +5,12 @@ dimensions:
 	P = 4 ;
 	L = 3 ;
 	R = 3 ;
-	B = 2 ;
-	T = 2 ;
-	TL = 1 ;
-	TR = 1 ;
-	BR = 1 ;
-	BL = 1 ;
-	L_periodic = UNLIMITED ; // (0 currently)
-	R_periodic = UNLIMITED ; // (0 currently)
-	B_periodic = 2 ;
-	T_periodic = 2 ;
-	TL_periodic = 1 ;
-	TR_periodic = 1 ;
-	BR_periodic = 1 ;
-	BL_periodic = 1 ;
+	B = 4 ;
+	T = 4 ;
+	TL = 2 ;
+	TR = 2 ;
+	BR = 2 ;
+	BL = 2 ;
 
 group: bounding_boxes {
   variables:
@@ -71,38 +63,6 @@ group: connectivity {
   	int bottom_left_neighbours(P) ;
   	int bottom_left_neighbour_ids(BL) ;
   	int bottom_left_neighbour_send(BL) ;
-  	int left_neighbours_periodic(P) ;
-  	int left_neighbour_ids_periodic(L_periodic) ;
-  	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_send_periodic(L_periodic) ;
-  	int left_neighbour_halo_recv_periodic(L_periodic) ;
-  	int right_neighbours_periodic(P) ;
-  	int right_neighbour_ids_periodic(R_periodic) ;
-  	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_send_periodic(R_periodic) ;
-  	int right_neighbour_halo_recv_periodic(R_periodic) ;
-  	int bottom_neighbours_periodic(P) ;
-  	int bottom_neighbour_ids_periodic(B_periodic) ;
-  	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
-  	int top_neighbours_periodic(P) ;
-  	int top_neighbour_ids_periodic(T_periodic) ;
-  	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_send_periodic(T_periodic) ;
-  	int top_neighbour_halo_recv_periodic(T_periodic) ;
-  	int top_left_neighbours_periodic(P) ;
-  	int top_left_neighbour_ids_periodic(TL_periodic) ;
-  	int top_left_neighbour_send_periodic(TL_periodic) ;
-  	int top_right_neighbours_periodic(P) ;
-  	int top_right_neighbour_ids_periodic(TR_periodic) ;
-  	int top_right_neighbour_send_periodic(TR_periodic) ;
-  	int bottom_right_neighbours_periodic(P) ;
-  	int bottom_right_neighbour_ids_periodic(BR_periodic) ;
-  	int bottom_right_neighbour_send_periodic(BR_periodic) ;
-  	int bottom_left_neighbours_periodic(P) ;
-  	int bottom_left_neighbour_ids_periodic(BL_periodic) ;
-  	int bottom_left_neighbour_send_periodic(BL_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2, 1 ;
@@ -125,96 +85,48 @@ group: connectivity {
 
    right_neighbour_halo_recv = 3, 3, 6 ;
 
-   bottom_neighbours = 0, 1, 0, 1 ;
+   bottom_neighbours = 1, 1, 1, 1 ;
 
-   bottom_neighbour_ids = 0, 2 ;
+   bottom_neighbour_ids = 1, 0, 3, 2 ;
 
-   bottom_neighbour_halos = 3, 4 ;
+   bottom_neighbour_halos = 3, 3, 4, 4 ;
 
-   bottom_neighbour_halo_send = 5, 9 ;
+   bottom_neighbour_halo_send = 8, 5, 6, 9 ;
 
-   bottom_neighbour_halo_recv = 0, 0 ;
+   bottom_neighbour_halo_recv = 0, 0, 0, 0 ;
 
-   top_neighbours = 1, 0, 1, 0 ;
+   top_neighbours = 1, 1, 1, 1 ;
 
-   top_neighbour_ids = 1, 3 ;
+   top_neighbour_ids = 1, 0, 3, 2 ;
 
-   top_neighbour_halos = 3, 4 ;
+   top_neighbour_halos = 3, 3, 4, 4 ;
 
-   top_neighbour_halo_send = 0, 0 ;
+   top_neighbour_halo_send = 0, 0, 0, 0 ;
 
-   top_neighbour_halo_recv = 5, 9 ;
+   top_neighbour_halo_recv = 5, 8, 9, 6 ;
 
-   top_left_neighbours = 0, 0, 1, 0 ;
+   top_left_neighbours = 0, 0, 1, 1 ;
 
-   top_left_neighbour_ids = 1 ;
+   top_left_neighbour_ids = 1, 0 ;
 
-   top_left_neighbour_send = 6 ;
+   top_left_neighbour_send = 6, 3 ;
 
-   top_right_neighbours = 1, 0, 0, 0 ;
+   top_right_neighbours = 1, 1, 0, 0 ;
 
-   top_right_neighbour_ids = 2 ;
+   top_right_neighbour_ids = 2, 2 ;
 
-   top_right_neighbour_send = 15 ;
+   top_right_neighbour_send = 15, 13 ;
 
-   bottom_right_neighbours = 0, 1, 0, 0 ;
+   bottom_right_neighbours = 1, 1, 0, 0 ;
 
-   bottom_right_neighbour_ids = 2 ;
+   bottom_right_neighbour_ids = 3, 2 ;
 
-   bottom_right_neighbour_send = 14 ;
+   bottom_right_neighbour_send = 11, 14 ;
 
-   bottom_left_neighbours = 0, 0, 0, 1 ;
+   bottom_left_neighbours = 0, 0, 1, 1 ;
 
-   bottom_left_neighbour_ids = 1 ;
+   bottom_left_neighbour_ids = 1, 1 ;
 
-   bottom_left_neighbour_send = 5 ;
-
-   left_neighbours_periodic = 0, 0, 0, 0 ;
-
-   right_neighbours_periodic = 0, 0, 0, 0 ;
-
-   bottom_neighbours_periodic = 1, 0, 1, 0 ;
-
-   bottom_neighbour_ids_periodic = 1, 3 ;
-
-   bottom_neighbour_halos_periodic = 3, 4 ;
-
-   bottom_neighbour_halo_send_periodic = 8, 6 ;
-
-   bottom_neighbour_halo_recv_periodic = 0, 0 ;
-
-   top_neighbours_periodic = 0, 1, 0, 1 ;
-
-   top_neighbour_ids_periodic = 0, 2 ;
-
-   top_neighbour_halos_periodic = 3, 4 ;
-
-   top_neighbour_halo_send_periodic = 0, 0 ;
-
-   top_neighbour_halo_recv_periodic = 8, 6 ;
-
-   top_left_neighbours_periodic = 0, 0, 0, 1 ;
-
-   top_left_neighbour_ids_periodic = 0 ;
-
-   top_left_neighbour_send_periodic = 3 ;
-
-   top_right_neighbours_periodic = 0, 1, 0, 0 ;
-
-   top_right_neighbour_ids_periodic = 2 ;
-
-   top_right_neighbour_send_periodic = 13 ;
-
-   bottom_right_neighbours_periodic = 1, 0, 0, 0 ;
-
-   bottom_right_neighbour_ids_periodic = 3 ;
-
-   bottom_right_neighbour_send_periodic = 11 ;
-
-   bottom_left_neighbours_periodic = 0, 0, 1, 0 ;
-
-   bottom_left_neighbour_ids_periodic = 1 ;
-
-   bottom_left_neighbour_send_periodic = 7 ;
+   bottom_left_neighbour_send = 7, 5 ;
   } // group connectivity
 }

--- a/test/test_tripolar_2/ref_partition_mask_2.cdl
+++ b/test/test_tripolar_2/ref_partition_mask_2.cdl
@@ -1,0 +1,17 @@
+netcdf partition_mask_2 {
+dimensions:
+	y = 4 ;
+	x = 6 ;
+variables:
+	int pid(y, x) ;
+
+// global attributes:
+		:num_processes = 2 ;
+data:
+
+ pid =
+  0, 0, 0, 1, 1, 1,
+  0, 0, 0, 1, 1, 1,
+  0, 0, 0, 1, 1, 1,
+  0, 0, 0, 1, 1, 1 ;
+}

--- a/test/test_tripolar_2/ref_partition_metadata_2.cdl
+++ b/test/test_tripolar_2/ref_partition_metadata_2.cdl
@@ -1,0 +1,116 @@
+netcdf partition_metadata_2 {
+dimensions:
+	NX = 6 ;
+	NY = 4 ;
+	P = 2 ;
+	L = 2 ;
+	R = 2 ;
+	B = UNLIMITED ; // (0 currently)
+	T = 2 ;
+	TL = 1 ;
+	TR = 1 ;
+	BR = UNLIMITED ; // (0 currently)
+	BL = UNLIMITED ; // (0 currently)
+
+group: bounding_boxes {
+  variables:
+  	int domain_x(P) ;
+  	int domain_extent_x(P) ;
+  	int domain_y(P) ;
+  	int domain_extent_y(P) ;
+  data:
+
+   domain_x = 0, 3 ;
+
+   domain_extent_x = 3, 3 ;
+
+   domain_y = 0, 0 ;
+
+   domain_extent_y = 4, 4 ;
+  } // group bounding_boxes
+
+group: connectivity {
+  variables:
+  	int left_neighbours(P) ;
+  	int left_neighbour_ids(L) ;
+  	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
+  	int right_neighbours(P) ;
+  	int right_neighbour_ids(R) ;
+  	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
+  	int bottom_neighbours(P) ;
+  	int bottom_neighbour_ids(B) ;
+  	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
+  	int top_neighbours(P) ;
+  	int top_neighbour_ids(T) ;
+  	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
+  	int top_left_neighbours(P) ;
+  	int top_left_neighbour_ids(TL) ;
+  	int top_left_neighbour_send(TL) ;
+  	int top_right_neighbours(P) ;
+  	int top_right_neighbour_ids(TR) ;
+  	int top_right_neighbour_send(TR) ;
+  	int bottom_right_neighbours(P) ;
+  	int bottom_right_neighbour_ids(BR) ;
+  	int bottom_right_neighbour_send(BR) ;
+  	int bottom_left_neighbours(P) ;
+  	int bottom_left_neighbour_ids(BL) ;
+  	int bottom_left_neighbour_send(BL) ;
+  data:
+
+   left_neighbours = 1, 1 ;
+
+   left_neighbour_ids = 1, 0 ;
+
+   left_neighbour_halos = 4, 4 ;
+
+   left_neighbour_halo_send = 3, 3 ;
+
+   left_neighbour_halo_recv = 10, 10 ;
+
+   right_neighbours = 1, 1 ;
+
+   right_neighbour_ids = 1, 0 ;
+
+   right_neighbour_halos = 4, 4 ;
+
+   right_neighbour_halo_send = 10, 10 ;
+
+   right_neighbour_halo_recv = 3, 3 ;
+
+   bottom_neighbours = 0, 0 ;
+
+   top_neighbours = 1, 1 ;
+
+   top_neighbour_ids = 1, 0 ;
+
+   top_neighbour_halos = 3, 3 ;
+
+   top_neighbour_halo_send = 7, 7 ;
+
+   top_neighbour_halo_recv = 7, 7 ;
+
+   top_left_neighbours = 0, 1 ;
+
+   top_left_neighbour_ids = 1 ;
+
+   top_left_neighbour_send = 13 ;
+
+   top_right_neighbours = 1, 0 ;
+
+   top_right_neighbour_ids = 0 ;
+
+   top_right_neighbour_send = 6 ;
+
+   bottom_right_neighbours = 0, 0 ;
+
+   bottom_left_neighbours = 0, 0 ;
+  } // group connectivity
+}

--- a/test/tripolar_grid.cdl
+++ b/test/tripolar_grid.cdl
@@ -1,0 +1,16 @@
+netcdf tripolar_grid {
+dimensions:
+	x = 6 ;
+	y = 4 ;
+variables:
+	int mask(y, x) ;
+
+	:title = "Tripolar grid example" ;
+data:
+
+mask =
+	1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1,
+	1, 1, 1, 1, 1, 1 ;
+}

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,9 +1,7 @@
 
 
 add_executable(unit_tests main.cpp)
-target_link_libraries(
-  unit_tests
-  PRIVATE doctest::doctest ${PROJECT_NAME}::${LIB_NAME})
+target_link_libraries(unit_tests PRIVATE doctest::doctest ${INTERNAL_CORE_NAME})
 target_include_directories(
   unit_tests
   PRIVATE ${CMAKE_SOURCE_DIR} ${DOCTEST_INCLUDE_DIR})

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+
+add_executable(unit_tests main.cpp)
+target_link_libraries(
+  unit_tests
+  PRIVATE doctest::doctest ${PROJECT_NAME}::${LIB_NAME})
+target_include_directories(
+  unit_tests
+  PRIVATE ${CMAKE_SOURCE_DIR} ${DOCTEST_INCLUDE_DIR})
+
+add_test(NAME unit_tests COMMAND unit_tests)

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-add_executable(unit_tests main.cpp)
+add_executable(unit_tests main.cpp test_DomainUtils.cpp)
 target_link_libraries(unit_tests PRIVATE doctest::doctest ${INTERNAL_CORE_NAME})
 target_include_directories(
   unit_tests

--- a/unit_test/main.cpp
+++ b/unit_test/main.cpp
@@ -6,3 +6,14 @@
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
+
+#include "DomainUtils.hpp"
+
+
+TEST_CASE("Use symbol"){
+    // Placeholder test to verify symbol visibility when compiling tests
+    Domain d{{0,1}, {2,3}};
+
+    CHECK(d.getWidth() == 2);
+    CHECK(d.getHeight() == 2);
+}

--- a/unit_test/main.cpp
+++ b/unit_test/main.cpp
@@ -1,0 +1,8 @@
+/*!
+ * @file main.cpp
+ *
+ * Test driver for the lightweight unit tests 
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest/doctest.h"

--- a/unit_test/test_DomainUtils.cpp
+++ b/unit_test/test_DomainUtils.cpp
@@ -65,10 +65,10 @@ TEST_CASE("Point arithmetic")
     }
 }
 
-TEST_CASE("Domain construction")
+TEST_SUITE("Domain construction")
 {
 
-    SUBCASE("Points in Normalised order")
+    TEST_CASE("Points in Normalised order")
     {
         const Point p1 { 1, 2 };
         const Point p2 { 3, 4 };
@@ -77,7 +77,7 @@ TEST_CASE("Domain construction")
         CHECK(d.p2 == Point { 3, 4 });
     }
 
-    SUBCASE("Point 1 right of Point 2")
+    TEST_CASE("Point 1 right of Point 2")
     {
         const Point p1 { 3, 2 };
         const Point p2 { 1, 4 };
@@ -86,7 +86,7 @@ TEST_CASE("Domain construction")
         CHECK(d.p2 == Point { 3, 4 });
     }
 
-    SUBCASE("Point 1 above Point 2")
+    TEST_CASE("Point 1 above Point 2")
     {
         const Point p1 { 1, 4 };
         const Point p2 { 3, 2 };
@@ -95,7 +95,7 @@ TEST_CASE("Domain construction")
         CHECK(d.p2 == Point { 3, 4 });
     }
 
-    SUBCASE("Point 1 right and above Point 2")
+    TEST_CASE("Point 1 right and above Point 2")
     {
         const Point p1 { 3, 4 };
         const Point p2 { 1, 2 };
@@ -115,9 +115,10 @@ TEST_CASE("Domain Getters")
     CHECK(d.getHeight() == 2);
 }
 
-TEST_CASE("Domain status")
+TEST_SUITE("Domain status")
 {
-    SUBCASE("Empty domain")
+
+    TEST_CASE("Empty domain")
     {
         const Point p1 { 0, 0 };
         const Point p2 { -1, -1 };
@@ -129,7 +130,7 @@ TEST_CASE("Domain status")
         CHECK(!d.isArea());
     }
 
-    SUBCASE("Point domain")
+    TEST_CASE("Point domain")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 0, 0 };
@@ -141,7 +142,7 @@ TEST_CASE("Domain status")
         CHECK(!d.isArea());
     }
 
-    SUBCASE("Line domain - vertical")
+    TEST_CASE("Line domain - vertical")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 0, 4 };
@@ -153,7 +154,7 @@ TEST_CASE("Domain status")
         CHECK(!d.isArea());
     }
 
-    SUBCASE("Line domain - horizontal")
+    TEST_CASE("Line domain - horizontal")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 4, 0 };
@@ -165,7 +166,7 @@ TEST_CASE("Domain status")
         CHECK(!d.isArea());
     }
 
-    SUBCASE("Normal domain")
+    TEST_CASE("Normal domain")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 4, 4 };
@@ -178,10 +179,10 @@ TEST_CASE("Domain status")
     }
 }
 
-TEST_CASE("Domain - Point symmetry reflection")
+TEST_SUITE("Domain - Point symmetry reflection")
 {
 
-    SUBCASE("Full domain in positive quadrant")
+    TEST_CASE("Full domain in positive quadrant")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 2, 1 };
@@ -194,7 +195,7 @@ TEST_CASE("Domain - Point symmetry reflection")
         CHECK(reflected.p2 == Point { 4, 4 });
     }
 
-    SUBCASE("Full domain across quadrants")
+    TEST_CASE("Full domain across quadrants")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 2, 1 };
@@ -207,7 +208,7 @@ TEST_CASE("Domain - Point symmetry reflection")
         CHECK(reflected.p2 == Point { 0, 0 });
     }
 
-    SUBCASE("Identity map")
+    TEST_CASE("Identity map")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 4, 2 };
@@ -220,7 +221,7 @@ TEST_CASE("Domain - Point symmetry reflection")
         CHECK(reflected.p2 == Point { 4, 2 });
     }
 
-    SUBCASE("Point domain")
+    TEST_CASE("Point domain")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 0, 0 };
@@ -233,7 +234,7 @@ TEST_CASE("Domain - Point symmetry reflection")
         CHECK(reflected.p2 == Point { 4, 2 });
     }
 
-    SUBCASE("Line domain - vertical")
+    TEST_CASE("Line domain - vertical")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 0, 4 };
@@ -246,7 +247,7 @@ TEST_CASE("Domain - Point symmetry reflection")
         CHECK(reflected.p2 == Point { 2, 2 });
     }
 
-    SUBCASE("Line domain - horizontal")
+    TEST_CASE("Line domain - horizontal")
     {
         const Point p1 { 0, 0 };
         const Point p2 { 4, 0 };
@@ -259,7 +260,7 @@ TEST_CASE("Domain - Point symmetry reflection")
         CHECK(reflected.p2 == Point { 6, 0 });
     }
 
-    SUBCASE("Empty domain")
+    TEST_CASE("Empty domain")
     {
         const Point p1 { 0, 0 };
         const Point p2 { -1, -1 };
@@ -287,9 +288,10 @@ bool equalDomains(const Domain& d1, const Domain& d2)
 }
 }
 
-TEST_CASE("Domain intersection")
+TEST_SUITE("Domain intersection")
 {
-    SUBCASE("2D intersection")
+
+    TEST_CASE("2D intersection")
     {
         const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
         const Domain d2 { Point { 2, 2 }, Point { 6, 6 } };
@@ -300,7 +302,7 @@ TEST_CASE("Domain intersection")
         CHECK(equalDomains(intersectionDomain, expectedIntersection));
     }
 
-    SUBCASE("2D disjoint intersection")
+    TEST_CASE("2D disjoint intersection")
     {
         const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
         const Domain d2 { Point { 7, 2 }, Point { 9, 6 } };
@@ -310,7 +312,7 @@ TEST_CASE("Domain intersection")
         CHECK(intersectionDomain.isEmpty());
     }
 
-    SUBCASE("Intersection with an empty set")
+    TEST_CASE("Intersection with an empty set")
     {
         const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
         const Domain d2 { Point { 7, 2 }, Point { 6, 6 } };
@@ -322,7 +324,7 @@ TEST_CASE("Domain intersection")
         CHECK(intersectionDomain.isEmpty());
     }
 
-    SUBCASE("Intersection with line overlap - vertical")
+    TEST_CASE("Intersection with line overlap - vertical")
     {
         const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
         const Domain d2 { Point { 6, 2 }, Point { 7, 6 } };
@@ -334,7 +336,7 @@ TEST_CASE("Domain intersection")
         CHECK(equalDomains(intersectionDomain, expectedIntersection));
     }
 
-    SUBCASE("Intersection with line overlap - horizontal")
+    TEST_CASE("Intersection with line overlap - horizontal")
     {
         const Domain d1 { Point { 0, 0 }, Point { 5, 2 } };
         const Domain d2 { Point { 1, -2 }, Point { 3, 0 } };
@@ -346,7 +348,7 @@ TEST_CASE("Domain intersection")
         CHECK(equalDomains(intersectionDomain, expectedIntersection));
     }
 
-    SUBCASE("Intersection with point overlap")
+    TEST_CASE("Intersection with point overlap")
     {
         const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
         const Domain d2 { Point { -3, -2 }, Point { 0, 0 } };

--- a/unit_test/test_DomainUtils.cpp
+++ b/unit_test/test_DomainUtils.cpp
@@ -1,0 +1,198 @@
+#include "DomainUtils.hpp"
+
+#include "doctest/doctest.h"
+
+TEST_CASE("Point equality")
+{
+    const Point p1 { 1, 2 };
+    const Point p2 { 1, 2 };
+    const Point p3 { 3, 4 };
+
+    CHECK(p1 == p2);
+    CHECK(p1 != p3);
+}
+
+TEST_CASE("Point arithmetic")
+{
+    // This is not the most sophisticated test
+    // It's purpose is to verify that the operators can be called and there is
+    // nothing silly going on (e.g. addition or x,y components beeing flipped)
+    // Single inputs should be enough to cover that
+    //
+    const int p_x = 1;
+    const int p_y = 2;
+
+    const Point p1 { p_x, p_y };
+
+    SUBCASE("Point + Point")
+    {
+        const int x = 3;
+        const int y = 4;
+
+        const Point p2 { x, y };
+        const Point p3 = p1 + p2;
+        CHECK(p3 == Point { p_x + x, p_y + y });
+    }
+
+    SUBCASE("Point - Point")
+    {
+        const int x = 3;
+        const int y = 4;
+
+        const Point p2 { x, y };
+        const Point p3 = p1 - p2;
+        CHECK(p3 == Point { p_x - x, p_y - y });
+    }
+
+    SUBCASE("Point * scalar")
+    {
+        const int scalar = 3;
+        const Point p2 = p1 * scalar;
+        CHECK(p2 == Point { p_x * scalar, p_y * scalar });
+    }
+
+    SUBCASE("scalar * Point")
+    {
+        const int scalar = 3;
+        const Point p2 = scalar * p1;
+        CHECK(p2 == Point { p_x * scalar, p_y * scalar });
+    }
+
+    SUBCASE("Negation")
+    {
+        const Point p2 = -p1;
+        CHECK(p2 == Point { -p_x, -p_y });
+    }
+}
+
+TEST_CASE("Domain construction")
+{
+
+    SUBCASE("Points in Normalised order")
+    {
+        const Point p1 { 1, 2 };
+        const Point p2 { 3, 4 };
+        const Domain d = Domain::fromTwoPoints(p1, p2);
+        CHECK(d.p1 == Point { 1, 2 });
+        CHECK(d.p2 == Point { 3, 4 });
+    }
+
+    SUBCASE("Point 1 right of Point 2")
+    {
+        const Point p1 { 3, 2 };
+        const Point p2 { 1, 4 };
+        const Domain d = Domain::fromTwoPoints(p1, p2);
+        CHECK(d.p1 == Point { 1, 2 });
+        CHECK(d.p2 == Point { 3, 4 });
+    }
+
+    SUBCASE("Point 1 above Point 2")
+    {
+        const Point p1 { 1, 4 };
+        const Point p2 { 3, 2 };
+        const Domain d = Domain::fromTwoPoints(p1, p2);
+        CHECK(d.p1 == Point { 1, 2 });
+        CHECK(d.p2 == Point { 3, 4 });
+    }
+
+    SUBCASE("Point 1 right and above Point 2")
+    {
+        const Point p1 { 3, 4 };
+        const Point p2 { 1, 2 };
+        const Domain d = Domain::fromTwoPoints(p1, p2);
+        CHECK(d.p1 == Point { 1, 2 });
+        CHECK(d.p2 == Point { 3, 4 });
+    }
+}
+
+TEST_CASE("Domain Getters")
+{
+    const Point p1 { 1, 2 };
+    const Point p2 { 4, 4 };
+    const Domain d { p1, p2 };
+
+    CHECK(d.getWidth() == 3);
+    CHECK(d.getHeight() == 2);
+}
+
+TEST_CASE("Domain - Point symmetry reflection")
+{
+
+    SUBCASE("Full domain in positive quadrant")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 2, 1 };
+        const Domain d { p1, p2 };
+
+        const Point p { 2, 2 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.p1 == Point { 2, 3 });
+        CHECK(reflected.p2 == Point { 4, 4 });
+    }
+
+    SUBCASE("Full domain across quadrants")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 2, 1 };
+        const Domain d { p1, p2 };
+
+        const Point p { 0, 0 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.p1 == Point { -2, -1 });
+        CHECK(reflected.p2 == Point { 0, 0 });
+    }
+
+    SUBCASE("Identity map")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 4, 2 };
+        const Domain d { p1, p2 };
+
+        const Point p { 2, 1 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.p1 == Point { 0, 0 });
+        CHECK(reflected.p2 == Point { 4, 2 });
+    }
+
+    SUBCASE("Point domain")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 0, 0 };
+        const Domain d { p1, p2 };
+
+        const Point p { 2, 1 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.p1 == Point { 4, 2 });
+        CHECK(reflected.p2 == Point { 4, 2 });
+    }
+
+    SUBCASE("Line domain - vertical")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 0, 4 };
+        const Domain d { p1, p2 };
+
+        const Point p { 1, 1 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.p1 == Point { 2, -2 });
+        CHECK(reflected.p2 == Point { 2, 2 });
+    }
+
+    SUBCASE("Line domain - horizontal")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 4, 0 };
+        const Domain d { p1, p2 };
+
+        const Point p { 3, 0 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.p1 == Point { 2, 0 });
+        CHECK(reflected.p2 == Point { 6, 0 });
+    }
+}

--- a/unit_test/test_DomainUtils.cpp
+++ b/unit_test/test_DomainUtils.cpp
@@ -115,6 +115,69 @@ TEST_CASE("Domain Getters")
     CHECK(d.getHeight() == 2);
 }
 
+TEST_CASE("Domain status")
+{
+    SUBCASE("Empty domain")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { -1, -1 };
+        const Domain d { p1, p2 };
+
+        CHECK(d.isEmpty());
+        CHECK(!d.isPoint());
+        CHECK(!d.isLine());
+        CHECK(!d.isArea());
+    }
+
+    SUBCASE("Point domain")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 0, 0 };
+        const Domain d { p1, p2 };
+
+        CHECK(!d.isEmpty());
+        CHECK(d.isPoint());
+        CHECK(!d.isLine());
+        CHECK(!d.isArea());
+    }
+
+    SUBCASE("Line domain - vertical")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 0, 4 };
+        const Domain d { p1, p2 };
+
+        CHECK(!d.isEmpty());
+        CHECK(!d.isPoint());
+        CHECK(d.isLine());
+        CHECK(!d.isArea());
+    }
+
+    SUBCASE("Line domain - horizontal")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 4, 0 };
+        const Domain d { p1, p2 };
+
+        CHECK(!d.isEmpty());
+        CHECK(!d.isPoint());
+        CHECK(d.isLine());
+        CHECK(!d.isArea());
+    }
+
+    SUBCASE("Normal domain")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { 4, 4 };
+        const Domain d { p1, p2 };
+
+        CHECK(!d.isEmpty());
+        CHECK(!d.isPoint());
+        CHECK(!d.isLine());
+        CHECK(d.isArea());
+    }
+}
+
 TEST_CASE("Domain - Point symmetry reflection")
 {
 
@@ -194,5 +257,104 @@ TEST_CASE("Domain - Point symmetry reflection")
 
         CHECK(reflected.p1 == Point { 2, 0 });
         CHECK(reflected.p2 == Point { 6, 0 });
+    }
+
+    SUBCASE("Empty domain")
+    {
+        const Point p1 { 0, 0 };
+        const Point p2 { -1, -1 };
+        const Domain d { p1, p2 };
+
+        const Point p { 3, 0 };
+        const Domain reflected = pointReflection(p, d);
+
+        CHECK(reflected.isEmpty());
+    }
+}
+
+namespace {
+bool equalDomains(const Domain& d1, const Domain& d2)
+{
+
+    // Empty domains are equal to each other
+    // and never equal to a non empty domain
+    if (d1.isEmpty() || d2.isEmpty()) {
+        return d1.isEmpty() && d2.isEmpty();
+    }
+
+    // Representation is unique so we can just compare the points
+    return d1.p1 == d2.p1 && d1.p2 == d2.p2;
+}
+}
+
+TEST_CASE("Domain intersection")
+{
+    SUBCASE("2D intersection")
+    {
+        const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
+        const Domain d2 { Point { 2, 2 }, Point { 6, 6 } };
+
+        const Domain expectedIntersection { Point { 2, 2 }, Point { 6, 4 } };
+        const Domain intersectionDomain = intersection(d1, d2);
+
+        CHECK(equalDomains(intersectionDomain, expectedIntersection));
+    }
+
+    SUBCASE("2D disjoint intersection")
+    {
+        const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
+        const Domain d2 { Point { 7, 2 }, Point { 9, 6 } };
+
+        const Domain intersectionDomain = intersection(d1, d2);
+
+        CHECK(intersectionDomain.isEmpty());
+    }
+
+    SUBCASE("Intersection with an empty set")
+    {
+        const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
+        const Domain d2 { Point { 7, 2 }, Point { 6, 6 } };
+
+        REQUIRE(d2.isEmpty());
+
+        const Domain intersectionDomain = intersection(d1, d2);
+
+        CHECK(intersectionDomain.isEmpty());
+    }
+
+    SUBCASE("Intersection with line overlap - vertical")
+    {
+        const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
+        const Domain d2 { Point { 6, 2 }, Point { 7, 6 } };
+
+        const Domain expectedIntersection { Point { 6, 2 }, Point { 6, 4 } };
+        const Domain intersectionDomain = intersection(d1, d2);
+
+        CHECK(intersectionDomain.isLine());
+        CHECK(equalDomains(intersectionDomain, expectedIntersection));
+    }
+
+    SUBCASE("Intersection with line overlap - horizontal")
+    {
+        const Domain d1 { Point { 0, 0 }, Point { 5, 2 } };
+        const Domain d2 { Point { 1, -2 }, Point { 3, 0 } };
+
+        const Domain expectedIntersection { Point { 1, 0 }, Point { 3, 0 } };
+        const Domain intersectionDomain = intersection(d1, d2);
+
+        CHECK(intersectionDomain.isLine());
+        CHECK(equalDomains(intersectionDomain, expectedIntersection));
+    }
+
+    SUBCASE("Intersection with point overlap")
+    {
+        const Domain d1 { Point { 0, 0 }, Point { 6, 4 } };
+        const Domain d2 { Point { -3, -2 }, Point { 0, 0 } };
+
+        const Domain expectedIntersection { Point { 0, 0 }, Point { 0, 0 } };
+        const Domain intersectionDomain = intersection(d1, d2);
+
+        CHECK(intersectionDomain.isPoint());
+        CHECK(equalDomains(intersectionDomain, expectedIntersection));
     }
 }


### PR DESCRIPTION
This PR is stacked on #95 and #87

Resolves #86 

Adds a 'least effort' support for the tripolar topology, here I have aimed to minimise any modification to the existing code. 

I am also sneaking a `set -u` in the integration test script since it improves error messages when one tries to run it locally without all the env variables set ;-) 

TODO:
- [ ] Assert preconditions. For example that the `x` size of the tripolar grid must be even. This (and potentially other) assumptions we are relying on need to be verified. I am thinking during the `Grid` construction
- [ ] Remove the `intersection` function. At the moment it is not used (and hence should not be commited yet). I haven't done it yet since getting it out of the history requires more work and I wanted to have this PR opened ASAP 
- [ ] Add more test case. In particular we need one with single rank and 2 domains but with the split that is 'off the centre'.

@TomMelt I think it would be a good to have a quick review of this PR, in particular 2nd pair of eyes to spot some edge cases that might appear would be appreciated. Especially if we can translate them into test. 

I want to hold off polishing this PR to after I can create a asister draft PR in the nextsim which will implement the halo exchange with the tripolar data.  